### PR TITLE
API Swagger 적용 & API 코드 리팩토링

### DIFF
--- a/src/main/java/com/uniclub/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/uniclub/domain/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.uniclub.domain.user.repository.UserRepository;
 import com.uniclub.global.exception.CustomException;
 import com.uniclub.global.exception.ErrorCode;
 import com.uniclub.global.security.JwtTokenProvider;
+import com.uniclub.global.swagger.AuthApiSpecification;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthApiSpecification {
     private final AuthService authService;
 
 

--- a/src/main/java/com/uniclub/domain/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/uniclub/domain/auth/dto/LoginRequestDto.java
@@ -1,16 +1,20 @@
 package com.uniclub.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "로그인 요청 DTO")
 @Getter
 @NoArgsConstructor
 public class LoginRequestDto {
 
+    @Schema(description = "학번", example = "202012345")
     @NotBlank(message = "학번을 입력해주세요.")
     private String studentId;
 
+    @Schema(description = "비밀번호", example = "qwer123!")
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 }

--- a/src/main/java/com/uniclub/domain/auth/dto/LoginResponseDto.java
+++ b/src/main/java/com/uniclub/domain/auth/dto/LoginResponseDto.java
@@ -1,13 +1,22 @@
 package com.uniclub.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+@Schema(description = "로그인 응답 DTO")
 @Getter
 public class LoginResponseDto {
+    @Schema(description = "유저 PK", example = "1")
     private final Long userId;
+
+    @Schema(description = "액세스 토큰값", example = "6B86B273FF34FCE19D6B804EFF5A3F5747ADA4EAA22F1D49C01E52DDB7875B4B")
     private final String accessToken;
+
+    @Schema(description = "토큰 타입", example = "Bearer")
     private final String tokenType = "Bearer";
+
+    @Schema(description = "토큰 유효시간", example = "3600")
     private final Long expiresIn;
 
     @Builder

--- a/src/main/java/com/uniclub/domain/auth/dto/RegisterRequestDto.java
+++ b/src/main/java/com/uniclub/domain/auth/dto/RegisterRequestDto.java
@@ -1,25 +1,32 @@
 package com.uniclub.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "회원가입 요청 DTO")
 @Getter
 @NoArgsConstructor
 public class RegisterRequestDto {
 
+    @Schema(description = "학번", example = "202012345")
     @NotBlank(message = "학번을 입력해주세요.")
     private String studentId;
 
+    @Schema(description = "비밀번호", example = "qwer123")
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 
+    @Schema(description = "사용자 이름", example = "홍길동")
     @NotBlank(message = "이름을 입력해주세요.")
     private String name;
 
     // 직접 입력받는 방식이면 NotBlank 필요, 선택 방식이면 필요 X
     // @NotBlank(message = "전공을 입력해주세요.")
+    @Schema(description = "사용자 전공", example = "컴퓨터공학부")
     private String major;
 
+    @Schema(description = "개인정보 약관 동의", example = "true")
     private boolean agreed;
 }

--- a/src/main/java/com/uniclub/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/uniclub/domain/category/controller/CategoryController.java
@@ -3,27 +3,29 @@ package com.uniclub.domain.category.controller;
 import com.uniclub.domain.category.dto.CategoryRequestDto;
 import com.uniclub.domain.category.dto.CategoryRequestDto;
 import com.uniclub.domain.category.service.CategoryService;
+import com.uniclub.global.swagger.CategoryApiSpecification;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/category")
 @RequiredArgsConstructor
-public class CategoryController {
+public class CategoryController implements CategoryApiSpecification {
 
     private final CategoryService categoryService;
 
     @PostMapping
-    public ResponseEntity<Long> createCategory(@Valid @RequestBody CategoryRequestDto request) {
-        Long id = categoryService.createCategory(request);
-        return ResponseEntity.ok(id);
+    public ResponseEntity<Long> createCategory(@Valid @RequestBody CategoryRequestDto categoryRequestDto) {
+        categoryService.createCategory(categoryRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @DeleteMapping("/{categoryId}")
     public ResponseEntity<Void> deleteCategory(@PathVariable Long categoryId) {
         categoryService.deleteCategory(categoryId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/uniclub/domain/category/dto/CategoryRequestDto.java
+++ b/src/main/java/com/uniclub/domain/category/dto/CategoryRequestDto.java
@@ -1,12 +1,13 @@
 package com.uniclub.domain.category.dto;
 
-import com.uniclub.domain.category.entity.CategoryType;
-import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
+@Schema(description = "카테고리 생성 요청 DTO")
 @Getter
 public class CategoryRequestDto {
+    @Schema(description = "카테고리 이름", example = "학술")
     @NotBlank(message = "카테고리 이름을 입력해주세요.")
-    private CategoryType name;
+    private String name;
 }

--- a/src/main/java/com/uniclub/domain/category/entity/CategoryType.java
+++ b/src/main/java/com/uniclub/domain/category/entity/CategoryType.java
@@ -1,5 +1,8 @@
 package com.uniclub.domain.category.entity;
 
+import com.uniclub.global.exception.CustomException;
+import com.uniclub.global.exception.ErrorCode;
+
 public enum CategoryType {
     LIBERAL_ACADEMIC,   //교양학술
     HOBBY_EXHIBITION,   //취미전시
@@ -7,4 +10,15 @@ public enum CategoryType {
     RELIGION,   //종교
     VOLUNTEER,  //봉사
     CULTURE;    //문화
+
+    // 카테고리 enum 타입, 문자열 비교 및 예외처리
+    public static CategoryType from(String input) {
+        for (CategoryType category : values()) {
+            if (category.name().equals(input)) {
+                return category;
+            }
+        }
+        throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
+    }
+
 }

--- a/src/main/java/com/uniclub/domain/category/service/CategoryService.java
+++ b/src/main/java/com/uniclub/domain/category/service/CategoryService.java
@@ -2,6 +2,7 @@ package com.uniclub.domain.category.service;
 
 import com.uniclub.domain.category.dto.CategoryRequestDto;
 import com.uniclub.domain.category.entity.Category;
+import com.uniclub.domain.category.entity.CategoryType;
 import com.uniclub.domain.category.repository.CategoryRepository;
 import com.uniclub.domain.club.entity.Club;
 import com.uniclub.domain.club.repository.ClubRepository;
@@ -19,11 +20,13 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
 
-    public Long createCategory(CategoryRequestDto request) {
-        if (categoryRepository.existsByName(request.getName())) { // 카테고리 중복 확인
+    public Long createCategory(CategoryRequestDto categoryRequestDto) {
+        CategoryType categoryName = CategoryType.from(categoryRequestDto.getName());
+
+        if (categoryRepository.existsByName(categoryName)) { // 카테고리 중복 확인
             throw new CustomException(ErrorCode.DUPLICATE_CATEGORY_NAME);
         }
-        Category saved = categoryRepository.save(new Category(request.getName()));
+        Category saved = categoryRepository.save(new Category(categoryName));
         return saved.getCategoryId();
     }
 

--- a/src/main/java/com/uniclub/domain/club/controller/ClubController.java
+++ b/src/main/java/com/uniclub/domain/club/controller/ClubController.java
@@ -1,67 +1,62 @@
 package com.uniclub.domain.club.controller;
 
-import com.uniclub.domain.category.entity.CategoryType;
 import com.uniclub.domain.club.dto.ClubCreateRequestDto;
 import com.uniclub.domain.club.dto.ClubPromotionRegisterRequestDto;
 import com.uniclub.domain.club.dto.ClubResponseDto;
 import com.uniclub.domain.club.service.ClubService;
-import com.uniclub.domain.user.entity.User;
 import com.uniclub.global.security.UserDetailsImpl;
+import com.uniclub.global.swagger.ClubApiSpecification;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/clubs")
-public class ClubController {
+public class ClubController implements ClubApiSpecification {
 
     private final ClubService clubService;
 
-    @GetMapping
-    public ResponseEntity<List<ClubResponseDto>> getAllClubs(
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        List<ClubResponseDto> result = clubService.getAllClubs(userDetails.getUser());
-        if (result.isEmpty()) return ResponseEntity.noContent().build();
-        return ResponseEntity.ok(result);
+    @GetMapping("/clubs")
+    public ResponseEntity<Slice<ClubResponseDto>> getClubs(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(required = false) String category,
+            @RequestParam(defaultValue = "name") String sortBy,
+            @RequestParam(required = false) String cursorName,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Slice<ClubResponseDto> result = clubService.getClubs(
+                userDetails.getUser().getUserId(), category, sortBy, cursorName, size
+        );
+        return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
-    @GetMapping("/category")
-    public ResponseEntity<List<ClubResponseDto>> getClubsByCategory(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestParam String category) {
-        CategoryType categoryType = CategoryType.valueOf(category);
-        List<ClubResponseDto> result = clubService.getClubsByCategory(userDetails.getUser(), categoryType);
-        if (result.isEmpty()) return ResponseEntity.noContent().build();
-        return ResponseEntity.ok(result);
-    }
 
     @PostMapping("/{clubId}/favorite")
     public ResponseEntity<String> toggleFavorite(
             @PathVariable Long clubId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        boolean isNowFavorite = clubService.toggleFavorite(clubId, userDetails.getUser());
+        boolean isNowFavorite = clubService.toggleFavorite(clubId, userDetails);
         String message = isNowFavorite ? "관심 동아리 등록 완료" : "관심 동아리 등록 취소 완료";
-        return ResponseEntity.ok(message);
+        return ResponseEntity.status(HttpStatus.OK).body(message);
     }
 
 
     @PostMapping
     public ResponseEntity<Void> createClub(@Valid @RequestBody ClubCreateRequestDto clubCreateRequestDto) {
         clubService.createClub(clubCreateRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(null);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PutMapping("/{clubId}")
-    public ResponseEntity<Void> promotionRegister(@AuthenticationPrincipal UserDetailsImpl user, @PathVariable Long clubId, @RequestBody ClubPromotionRegisterRequestDto clubPromotionRegisterRequestDto) {
-        clubService.saveClubPromotion(user, clubId, clubPromotionRegisterRequestDto);
-        return ResponseEntity.status(HttpStatus.OK).body(null);
+    public ResponseEntity<Void> promotionRegister(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long clubId, @RequestBody ClubPromotionRegisterRequestDto clubPromotionRegisterRequestDto) {
+        clubService.saveClubPromotion(userDetails, clubId, clubPromotionRegisterRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     /*
@@ -73,9 +68,9 @@ public class ClubController {
     */
 
     @DeleteMapping("/{clubId}")
-    private ResponseEntity<Void> deleteClub(@AuthenticationPrincipal UserDetailsImpl user, @PathVariable Long clubId) {
-        clubService.deleteClub(user, clubId);
-        return ResponseEntity.status(HttpStatus.OK).body(null);
+    public ResponseEntity<Void> deleteClub(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long clubId) {
+        clubService.deleteClub(userDetails, clubId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
 }

--- a/src/main/java/com/uniclub/domain/club/controller/ClubController.java
+++ b/src/main/java/com/uniclub/domain/club/controller/ClubController.java
@@ -62,7 +62,7 @@ public class ClubController implements ClubApiSpecification {
 
 
     @GetMapping("/{clubId}")
-    private ResponseEntity<ClubPromotionResponseDto> getClubPromotion(@PathVariable Long clubId) {
+    public ResponseEntity<ClubPromotionResponseDto> getClubPromotion(@PathVariable Long clubId) {
         ClubPromotionResponseDto clubPromotionResponseDto = clubService.getClubPromotion(clubId);
         return ResponseEntity.status(HttpStatus.OK).body(clubPromotionResponseDto);
     }

--- a/src/main/java/com/uniclub/domain/club/dto/ClubCreateRequestDto.java
+++ b/src/main/java/com/uniclub/domain/club/dto/ClubCreateRequestDto.java
@@ -1,15 +1,18 @@
 package com.uniclub.domain.club.dto;
 
 import com.uniclub.domain.club.entity.Club;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "동아리 생성 요청 DTO")
 @Getter
 @NoArgsConstructor
 public class ClubCreateRequestDto {
 
+    @Schema(description = "동아리 이름", example = "앱센터")
     @NotBlank(message = "동아리 이름을 입력해주세요.")
     private String name;    //동아리 이름
 

--- a/src/main/java/com/uniclub/domain/club/dto/ClubPromotionRegisterRequestDto.java
+++ b/src/main/java/com/uniclub/domain/club/dto/ClubPromotionRegisterRequestDto.java
@@ -76,10 +76,6 @@ public class ClubPromotionRegisterRequestDto {
                 .build();
     }
 
-    public List<String> getMediaLink() {
-        return mediaLinks;
-    }
-
 
 
 }

--- a/src/main/java/com/uniclub/domain/club/dto/ClubPromotionRegisterRequestDto.java
+++ b/src/main/java/com/uniclub/domain/club/dto/ClubPromotionRegisterRequestDto.java
@@ -3,40 +3,58 @@ package com.uniclub.domain.club.dto;
 import com.uniclub.domain.club.entity.Club;
 import com.uniclub.domain.club.entity.ClubStatus;
 import com.uniclub.domain.club.entity.Media;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "동아리 홍보게시글 생성 및 수정 요청 DTO")
 @Getter
 @NoArgsConstructor
 public class ClubPromotionRegisterRequestDto {
 
+    @Schema(description = "동아리 이름", example = "앱센터")
     private String name;
 
+    @Schema(description = "동아리 모집 현황", example = "CLOSED")
     private ClubStatus status;
 
+    @Schema(description = "모집 시작 시간", example = "2025-08-03T14:30:00")
     private LocalDateTime startTime;
 
+    @Schema(description = "모집 마감 시간", example = "2025-08-03T14:30:00")
     private LocalDateTime endTime;
 
+    @Schema(description = "소개글")
     private String description;
 
+    @Schema(description = "공지")
     private String notice;
 
+    @Schema(description = "동아리방 위치", example = "4호관 107호")
     private String location;
 
-    private String presidentInfo;
+    @Schema(description = "회장 이름", example = "홍길동")
+    private String presidentName;
 
+    @Schema(description = "회장 전화번호", example = "010-1234-5678")
+    private String presidentPhone;
+
+    @Schema(description = "유튜브 url")
     private String youtubeLink;
 
+    @Schema(description = "인스타그램 url")
     private String instagramLink;
 
+    @Schema(description = "프로필 이미지 url")
     private String profileImage;
 
+    @Schema(description = "배경 이미지 url")
     private String backgroundImage;
 
+    @Schema(description = "첨부 이미지, 영상 url")
     private List<String> mediaLink; //이건 Media에 저장
 
     //저장을 위해 Club Entity로 변환
@@ -49,7 +67,8 @@ public class ClubPromotionRegisterRequestDto {
                 .description(clubPromotionRegisterRequestDto.getDescription())
                 .notice(clubPromotionRegisterRequestDto.getNotice())
                 .location(clubPromotionRegisterRequestDto.getLocation())
-                .presidentInfo(clubPromotionRegisterRequestDto.getPresidentInfo())
+                .presidentName(clubPromotionRegisterRequestDto.getPresidentName())
+                .presidentPhone(clubPromotionRegisterRequestDto.getPresidentPhone())
                 .youtubeLink(clubPromotionRegisterRequestDto.getYoutubeLink())
                 .instagramLink(clubPromotionRegisterRequestDto.getInstagramLink())
                 .profileImage(clubPromotionRegisterRequestDto.getProfileImage())

--- a/src/main/java/com/uniclub/domain/club/dto/ClubPromotionResponseDto.java
+++ b/src/main/java/com/uniclub/domain/club/dto/ClubPromotionResponseDto.java
@@ -4,39 +4,58 @@ package com.uniclub.domain.club.dto;
 import com.uniclub.domain.club.entity.Club;
 import com.uniclub.domain.club.entity.ClubStatus;
 import com.uniclub.domain.club.entity.Media;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "동아리 홍보게시글 생성 및 수정 응답 DTO")
 @Getter
 public class ClubPromotionResponseDto {
+
+    @Schema(description = "동아리 이름", example = "앱센터")
     private String name;
 
+    @Schema(description = "동아리 모집 현황", example = "CLOSED")
     private ClubStatus status;
 
+    @Schema(description = "모집 시작 시간", example = "2025-08-03T14:30:00")
     private LocalDateTime startTime;
 
+    @Schema(description = "모집 마감 시간", example = "2025-08-03T14:30:00")
     private LocalDateTime endTime;
 
+    @Schema(description = "소개글")
     private String description;
 
+    @Schema(description = "공지")
     private String notice;
 
+    @Schema(description = "동아리방 위치", example = "4호관 107호")
     private String location;
 
-    private String presidentInfo;
+    @Schema(description = "회장 이름", example = "홍길동")
+    private String presidentName;
 
+    @Schema(description = "회장 전화번호", example = "010-1234-5678")
+    private String presidentPhone;
+
+    @Schema(description = "유튜브 url")
     private String youtubeLink;
 
+    @Schema(description = "인스타그램 url")
     private String instagramLink;
 
+    @Schema(description = "프로필 이미지 url")
     private String profileImage;
 
+    @Schema(description = "배경 이미지 url")
     private String backgroundImage;
 
-    private List<String> mediaLink;
+    @Schema(description = "첨부 이미지, 영상 url")
+    private List<String> mediaLink; //이건 Media에 저장
 
     @Builder
     private ClubPromotionResponseDto(Club club, Media media) {
@@ -47,7 +66,8 @@ public class ClubPromotionResponseDto {
         this.description = club.getDescription();
         this.notice = club.getNotice();
         this.location = club.getLocation();
-        this.presidentInfo = club.getPresidentInfo();
+        this.presidentName = club.getPresidentName();
+        this.presidentPhone = club.getPresidentPhone();
         this.youtubeLink = club.getYoutubeLink();
         this.instagramLink = club.getInstagramLink();
         this.profileImage = club.getProfileImage();

--- a/src/main/java/com/uniclub/domain/club/dto/ClubResponseDto.java
+++ b/src/main/java/com/uniclub/domain/club/dto/ClubResponseDto.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 
-@Schema(description = "동아리 리스트 조회 응답 DTO")
+@Schema(description = "동아리 조회 응답 DTO")
 @Getter
 public class ClubResponseDto {
 

--- a/src/main/java/com/uniclub/domain/club/dto/ClubResponseDto.java
+++ b/src/main/java/com/uniclub/domain/club/dto/ClubResponseDto.java
@@ -2,18 +2,30 @@ package com.uniclub.domain.club.dto;
 
 import com.uniclub.domain.club.entity.Club;
 import com.uniclub.domain.club.entity.ClubStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 
+@Schema(description = "동아리 리스트 조회 응답 DTO")
 @Getter
 public class ClubResponseDto {
+
+    @Schema(description = "동아리 PK", example = "1")
     private Long id;
+
+    @Schema(description = "동아리 이름", example = "앱센터")
     private String name;
+
+    @Schema(description = "동아리 소개글")
     private String info;
+
+    @Schema(description = "동아리 모집 상태", example = "CLOSED")
     private ClubStatus status;
+
+    @Schema(description = "관심동아리 여부", example = "true")
     private boolean favorite;
 
     @Builder

--- a/src/main/java/com/uniclub/domain/club/entity/Club.java
+++ b/src/main/java/com/uniclub/domain/club/entity/Club.java
@@ -42,7 +42,10 @@ public class Club extends BaseTime {
     private String location;
 
     @Column(length = 50)
-    private String presidentInfo;
+    private String presidentName;
+
+    @Column(length = 15)
+    private String presidentPhone;
 
     @Column(columnDefinition = "TEXT")
     private String youtubeLink;
@@ -62,7 +65,7 @@ public class Club extends BaseTime {
 
     @Builder
     public Club(String name, ClubStatus status, LocalDateTime startTime, LocalDateTime endTime,
-                String description, String notice, String location, String presidentInfo,
+                String description, String notice, String location, String presidentName, String presidentPhone,
                 String youtubeLink, String instagramLink, String profileImage, String backgroundImage,
                 Category category) {
   
@@ -73,7 +76,8 @@ public class Club extends BaseTime {
         this.description = description;
         this.notice = notice;
         this.location = location;
-        this.presidentInfo = presidentInfo;
+        this.presidentName = presidentName;
+        this.presidentPhone = presidentPhone;
         this.youtubeLink = youtubeLink;
         this.instagramLink = instagramLink;
         this.profileImage = profileImage;
@@ -88,7 +92,8 @@ public class Club extends BaseTime {
         this.description = club.getDescription();
         this.notice = club.getNotice();
         this.location = club.getLocation();
-        this.presidentInfo = club.getPresidentInfo();
+        this.presidentName = club.getPresidentName();
+        this.presidentPhone = club.getPresidentPhone();
         this.youtubeLink = club.getYoutubeLink();
         this.instagramLink = club.getInstagramLink();
         this.profileImage = club.getProfileImage();

--- a/src/main/java/com/uniclub/domain/club/repository/ClubRepository.java
+++ b/src/main/java/com/uniclub/domain/club/repository/ClubRepository.java
@@ -2,20 +2,51 @@ package com.uniclub.domain.club.repository;
 
 import com.uniclub.domain.category.entity.CategoryType;
 import com.uniclub.domain.club.entity.Club;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long> {
-    @Query("SELECT c FROM Club c JOIN c.category ca WHERE ca.name = :categoryName")
-    List<Club> findByCategoryName(CategoryType categoryName);
     Boolean existsByName(String name);
 
     @Query("SELECT c FROM Club c WHERE " +
             "(LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
             "LOWER(c.description) LIKE LOWER(CONCAT('%', :keyword, '%')))")
     List<Club> findByKeyword(String keyword);
+
+    // 이름순 + 카테고리
+    @Query("SELECT c FROM Club c " +
+            "WHERE (:category IS NULL OR c.category = :category) " +
+            "AND (:cursorName IS NULL OR c.name > :cursorName) " +
+            "ORDER BY c.name ASC")
+    Slice<Club> findClubsByCursorOrderByName(@Param("category") CategoryType category,
+                                             @Param("cursorName") String cursorName,
+                                             Pageable pageable);
+
+    // 좋아요순 + 카테고리
+    @Query("SELECT c FROM Club c " +
+            "LEFT JOIN Favorite f ON f.club = c AND f.user.userId = :userId " +
+            "WHERE (:category IS NULL OR c.category = :category) " +
+            "AND (:cursorName IS NULL OR c.name > :cursorName) " +
+            "ORDER BY CASE WHEN f.favoriteId IS NOT NULL THEN 0 ELSE 1 END, c.name ASC")
+    Slice<Club> findClubsByCursorOrderByFavorite(@Param("userId") Long userId,
+                                                 @Param("category") CategoryType category,
+                                                 @Param("cursorName") String cursorName,
+                                                 Pageable pageable);
+
+    // 모집중순 + 카테고리
+    @Query("SELECT c FROM Club c " +
+            "WHERE (:category IS NULL OR c.category = :category) " +
+            "AND (:cursorName IS NULL OR c.name > :cursorName) " +
+            "ORDER BY CASE WHEN c.status = 'ACTIVE' THEN 0 ELSE 1 END, c.name ASC")
+    Slice<Club> findClubsByCursorOrderByStatus(@Param("category") CategoryType category,
+                                               @Param("cursorName") String cursorName,
+                                               Pageable pageable);
+
 }

--- a/src/main/java/com/uniclub/domain/club/service/ClubService.java
+++ b/src/main/java/com/uniclub/domain/club/service/ClubService.java
@@ -104,14 +104,14 @@ public class ClubService {
     }
 
     //동아리 소개글 작성
-    public void saveClubPromotion(UserDetailsImpl user, Long clubId, ClubPromotionRegisterRequestDto promotionRegisterRequestDto) {
+    public void saveClubPromotion(UserDetailsImpl userDetails, Long clubId, ClubPromotionRegisterRequestDto promotionRegisterRequestDto) {
         Club existingClub = clubRepository.findById(clubId) //실제 존재하는 동아리인지 확인
                 .orElseThrow(
                         () -> new CustomException(ErrorCode.CLUB_NOT_FOUND)
                 );
 
         //해당 동아리의 회장인지 확인
-        Role userRole = checkRole(user.getUserId(), clubId);
+        Role userRole = checkRole(userDetails.getUserId(), clubId);
         if (userRole != Role.PRESIDENT) {
             throw new CustomException(ErrorCode.INSUFFICIENT_PERMISSION);
         }
@@ -120,7 +120,7 @@ public class ClubService {
         existingClub.update(promotionRegisterRequestDto.toClubEntity(promotionRegisterRequestDto));
 
         //미디어 저장 및 매핑
-        List<String> mediaLinks = promotionRegisterRequestDto.getMediaLink();
+        List<String> mediaLinks = promotionRegisterRequestDto.getMediaLinks();
         for (String mediaLink : mediaLinks) {
             Media media = saveMedia(mediaLink, existingClub);
             mediaRepository.save(media);
@@ -147,7 +147,7 @@ public class ClubService {
 
 
     //(개발자 전용) 동아리 삭제
-    public void deleteClub(UserDetailsImpl user, Long clubId) {
+    public void deleteClub(UserDetailsImpl userDetails, Long clubId) {
 
         clubRepository.findById(clubId).orElseThrow(
                 () -> new CustomException(ErrorCode.CLUB_NOT_FOUND)

--- a/src/main/java/com/uniclub/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/uniclub/domain/favorite/repository/FavoriteRepository.java
@@ -5,6 +5,7 @@ import com.uniclub.domain.favorite.entity.Favorite;
 import com.uniclub.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,8 +16,13 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     @Query("SELECT f.club.clubId FROM Favorite f WHERE f.user.userId = :userId")
     List<Long> findClubIdsByUserId(Long userId);
 
-    boolean existsByUserAndClub(User user, Club club);
+    @Query("""
+    SELECT CASE WHEN EXISTS (
+        SELECT 1 FROM Favorite f
+        WHERE f.user.userId = :userId AND f.club.clubId = :clubId
+    ) THEN true ELSE false END
+    """)
+    boolean existsByUserIdAndClubId(@Param("userId") Long userId, @Param("clubId") Long clubId);
+
     void deleteByUserAndClub(User user, Club club);
-
-
 }

--- a/src/main/java/com/uniclub/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/uniclub/domain/notification/controller/NotificationController.java
@@ -3,6 +3,7 @@ package com.uniclub.domain.notification.controller;
 import com.uniclub.domain.notification.dto.NotificationResponseDto;
 import com.uniclub.domain.notification.service.NotificationService;
 import com.uniclub.global.security.UserDetailsImpl;
+import com.uniclub.global.swagger.NotificationApiSpecification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,14 +17,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users/notifications")
-public class NotificationController {
+public class NotificationController implements NotificationApiSpecification {
 
     private final NotificationService notificationService;
 
 
     @GetMapping
-    public ResponseEntity<List<NotificationResponseDto>> getNotification(@AuthenticationPrincipal UserDetailsImpl user) {
-        List<NotificationResponseDto> notificationResponseDtoList = notificationService.getNotification(user);
+    public ResponseEntity<List<NotificationResponseDto>> getNotification(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<NotificationResponseDto> notificationResponseDtoList = notificationService.getNotification(userDetails);
         return ResponseEntity.status(HttpStatus.OK).body(notificationResponseDtoList);
     }
 }

--- a/src/main/java/com/uniclub/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/uniclub/domain/notification/dto/NotificationResponseDto.java
@@ -2,20 +2,26 @@ package com.uniclub.domain.notification.dto;
 
 import com.uniclub.domain.notification.entity.Notification;
 import com.uniclub.domain.notification.entity.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "알림 조회 응답 DTO")
 @Getter
 public class NotificationResponseDto {
 
+    @Schema(description = "알림 메시지", example = "질문에 답변이 도착했어요.")
     private final String message;
 
+    @Schema(description = "읽음 여부", example = "false")
     private final boolean isRead;
 
+    @Schema(description = "알림 종류", example = "PERSONAL")
     private final NotificationType type;
 
+    @Schema(description = "알림 생성 시간", example = "2025-08-03T14:30:00")
     private final LocalDateTime createdAt;
 
     @Builder

--- a/src/main/java/com/uniclub/domain/search/controller/SearchController.java
+++ b/src/main/java/com/uniclub/domain/search/controller/SearchController.java
@@ -4,6 +4,7 @@ import com.uniclub.domain.club.dto.ClubResponseDto;
 import com.uniclub.domain.club.repository.ClubRepository;
 import com.uniclub.domain.search.service.SearchService;
 import com.uniclub.global.security.UserDetailsImpl;
+import com.uniclub.global.swagger.SearchApiSpecification;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
@@ -19,13 +20,13 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/search")
-public class SearchController {
+public class SearchController implements SearchApiSpecification {
 
     private final SearchService searchService;
 
     @GetMapping
-    public ResponseEntity<List<ClubResponseDto>> search(@AuthenticationPrincipal UserDetailsImpl user, @RequestParam String keyword) {
-        List<ClubResponseDto> clubResponseDtoList = searchService.search(user, keyword);
+    public ResponseEntity<List<ClubResponseDto>> search(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam String keyword) {
+        List<ClubResponseDto> clubResponseDtoList = searchService.search(userDetails, keyword);
         return ResponseEntity.status(HttpStatus.OK).body(clubResponseDtoList);
     }
 }

--- a/src/main/java/com/uniclub/domain/search/service/SearchService.java
+++ b/src/main/java/com/uniclub/domain/search/service/SearchService.java
@@ -24,10 +24,10 @@ public class SearchService {
 
 
     @Transactional(readOnly = true)
-    public List<ClubResponseDto> search(UserDetailsImpl user, String keyword) {
+    public List<ClubResponseDto> search(UserDetailsImpl userDetails, String keyword) {
         List<Club> clubs = clubRepository.findByKeyword(keyword);   //키워드를 통해 동아리 명, 설명글을 조회하여 관련 동아리 목록 가져오기
 
-        List<Long> favorites = favoriteRepository.findClubIdsByUserId(user.getUserId());    //좋아요 누른 동아리 아이디 조회
+        List<Long> favorites = favoriteRepository.findClubIdsByUserId(userDetails.getUserId());    //좋아요 누른 동아리 아이디 조회
 
         List<ClubResponseDto> clubResponseDtoList = new ArrayList<>();
         Set<Long> favoriteSet = new HashSet<>(favorites);   //성능 최적화 시간 복잡도 O(n) -> O(1)

--- a/src/main/java/com/uniclub/domain/user/controller/UserController.java
+++ b/src/main/java/com/uniclub/domain/user/controller/UserController.java
@@ -3,6 +3,8 @@ package com.uniclub.domain.user.controller;
 import com.uniclub.domain.user.dto.InformationModificationRequestDto;
 import com.uniclub.domain.user.service.UserService;
 import com.uniclub.global.security.UserDetailsImpl;
+import com.uniclub.global.swagger.SearchApiSpecification;
+import com.uniclub.global.swagger.UserApiSpecification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,16 +18,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
-public class UserController {
+public class UserController implements UserApiSpecification {
 
     private final UserService userService;
 
     @PatchMapping("/me")
     public ResponseEntity<Void> updateUser(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestBody InformationModificationRequestDto request
+            @RequestBody InformationModificationRequestDto informationModificationRequestDto
     ) {
-        userService.updateUser(userDetails, request);
+        userService.updateUser(userDetails, informationModificationRequestDto);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/src/main/java/com/uniclub/domain/user/dto/InformationModificationRequestDto.java
+++ b/src/main/java/com/uniclub/domain/user/dto/InformationModificationRequestDto.java
@@ -1,9 +1,15 @@
 package com.uniclub.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+@Schema(description = "유저 개인정보 수정 요청 DTO")
 @Getter
 public class InformationModificationRequestDto {
+
+    @Schema(description = "이름", example = "홍길동")
     private String name;
+
+    @Schema(description = "전공", example = "컴퓨터공학부")
     private String major;
 }

--- a/src/main/java/com/uniclub/domain/user/service/UserService.java
+++ b/src/main/java/com/uniclub/domain/user/service/UserService.java
@@ -16,13 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final UserRepository userRepository;
 
-    public void updateUser(UserDetailsImpl userDetails, InformationModificationRequestDto request) {
+    public void updateUser(UserDetailsImpl userDetails, InformationModificationRequestDto informationModificationRequestDto) {
         // 유저 조회, 존재하지 않는 경우 예외처리
         User user = userRepository.findByStudentId(userDetails.getStudentId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 영속성 컨택스트 이용(더티체킹)
-        user.updateInfo(request.getName(), request.getMajor());
+        user.updateInfo(informationModificationRequestDto.getName(), informationModificationRequestDto.getMajor());
     }
 
     public void deleteUser(UserDetailsImpl userDetails) {

--- a/src/main/java/com/uniclub/global/exception/ErrorCode.java
+++ b/src/main/java/com/uniclub/global/exception/ErrorCode.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+
+    INVALID_SORT_CONDITION(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 정렬 기준입니다."),
     NOT_AGREED(HttpStatus.BAD_REQUEST, 400, "개인정보 약관에 동의해야 합니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 유저를 찾을 수 없습니다."),
     DUPLICATE_STUDENT_ID(HttpStatus.CONFLICT, 409, "이미 존재하는 계정입니다."),

--- a/src/main/java/com/uniclub/global/swagger/AuthApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/AuthApiSpecification.java
@@ -1,0 +1,20 @@
+package com.uniclub.global.swagger;
+
+
+import com.uniclub.domain.auth.dto.LoginRequestDto;
+import com.uniclub.domain.auth.dto.LoginResponseDto;
+import com.uniclub.domain.auth.dto.RegisterRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "인증 API")
+public interface AuthApiSpecification {
+    @Operation(summary = "회원가입")
+    public ResponseEntity<Void> createUser(@Valid @RequestBody RegisterRequestDto request);
+
+    @Operation(summary = "로그인")
+    public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto loginRequestDto);
+}

--- a/src/main/java/com/uniclub/global/swagger/CategoryApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/CategoryApiSpecification.java
@@ -1,0 +1,18 @@
+package com.uniclub.global.swagger;
+
+import com.uniclub.domain.category.dto.CategoryRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "카테고리 API")
+public interface CategoryApiSpecification {
+    @Operation(summary = "카테고리 생성")
+    public ResponseEntity<Long> createCategory(@Valid @RequestBody CategoryRequestDto categoryRequestDto);
+
+    @Operation(summary = "카테고리 삭제")
+    public ResponseEntity<Void> deleteCategory(@PathVariable Long categoryId);
+}

--- a/src/main/java/com/uniclub/global/swagger/ClubApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/ClubApiSpecification.java
@@ -1,0 +1,53 @@
+package com.uniclub.global.swagger;
+
+import com.uniclub.domain.category.entity.CategoryType;
+import com.uniclub.domain.club.dto.ClubCreateRequestDto;
+import com.uniclub.domain.club.dto.ClubPromotionRegisterRequestDto;
+import com.uniclub.domain.club.dto.ClubResponseDto;
+import com.uniclub.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "동아리 API")
+public interface ClubApiSpecification {
+    @Operation(summary = "동아리 조회", description = "전체, 카테고리별, 정렬순 조회")
+    public ResponseEntity<Slice<ClubResponseDto>> getClubs(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(required = false) String category,
+            @RequestParam(defaultValue = "name") String sortBy,
+            @RequestParam(required = false) String cursorName,
+            @RequestParam(defaultValue = "10") int size
+    );
+
+    @Operation(summary = "관심동아리 등록/취소")
+    public ResponseEntity<String> toggleFavorite(
+            @PathVariable Long clubId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails);
+
+    @Operation(summary = "동아리 등록")
+    public ResponseEntity<Void> createClub(
+            @Valid @RequestBody ClubCreateRequestDto clubCreateRequestDto);
+
+    @Operation(summary = "동아리 홍보페이지 작성 및 수정")
+    public ResponseEntity<Void> promotionRegister(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long clubId,
+            @RequestBody ClubPromotionRegisterRequestDto clubPromotionRegisterRequestDto);
+
+    @Operation(summary = "동아리 삭제")
+    public ResponseEntity<Void> deleteClub(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long clubId);
+}

--- a/src/main/java/com/uniclub/global/swagger/ClubApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/ClubApiSpecification.java
@@ -3,6 +3,7 @@ package com.uniclub.global.swagger;
 import com.uniclub.domain.category.entity.CategoryType;
 import com.uniclub.domain.club.dto.ClubCreateRequestDto;
 import com.uniclub.domain.club.dto.ClubPromotionRegisterRequestDto;
+import com.uniclub.domain.club.dto.ClubPromotionResponseDto;
 import com.uniclub.domain.club.dto.ClubResponseDto;
 import com.uniclub.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,6 +46,9 @@ public interface ClubApiSpecification {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable Long clubId,
             @RequestBody ClubPromotionRegisterRequestDto clubPromotionRegisterRequestDto);
+
+    @Operation(summary = "동아리 홍보페이지 조회")
+    public ResponseEntity<ClubPromotionResponseDto> getClubPromotion(@PathVariable Long clubId);
 
     @Operation(summary = "동아리 삭제")
     public ResponseEntity<Void> deleteClub(

--- a/src/main/java/com/uniclub/global/swagger/NotificationApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/NotificationApiSpecification.java
@@ -1,0 +1,16 @@
+package com.uniclub.global.swagger;
+
+import com.uniclub.domain.notification.dto.NotificationResponseDto;
+import com.uniclub.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.util.List;
+
+@Tag(name = "알림 API")
+public interface NotificationApiSpecification {
+    @Operation(summary = "알림 리스트 조회")
+    public ResponseEntity<List<NotificationResponseDto>> getNotification(@AuthenticationPrincipal UserDetailsImpl user);
+}

--- a/src/main/java/com/uniclub/global/swagger/SearchApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/SearchApiSpecification.java
@@ -1,0 +1,19 @@
+package com.uniclub.global.swagger;
+
+import com.uniclub.domain.club.dto.ClubResponseDto;
+import com.uniclub.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "검색 API")
+public interface SearchApiSpecification {
+    @Operation(summary = "동아리 검색 API", description = "사용자가 입력한 검색어로 동아리 검색")
+    public ResponseEntity<List<ClubResponseDto>> search(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam String keyword);
+}

--- a/src/main/java/com/uniclub/global/swagger/UserApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/UserApiSpecification.java
@@ -1,0 +1,21 @@
+package com.uniclub.global.swagger;
+
+import com.uniclub.domain.user.dto.InformationModificationRequestDto;
+import com.uniclub.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "유저 API")
+public interface UserApiSpecification {
+    @Operation(summary = "유저 개인정보 수정")
+    public ResponseEntity<Void> updateUser(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody InformationModificationRequestDto informationModificationRequestDto
+    );
+
+    @Operation(summary = "회원 탈퇴")
+    public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails);
+}


### PR DESCRIPTION
1. 인터페이스로 API 코드에 swagger 적용 (추후 @ApiResponse로 응답 형태도 추가할 예정)
2. 동아리 리스트 무한스크롤 API 작성 완료
3. 컨트롤러단 API 코드 private -> public 수정
4. 일부 변수명 불일치 (user -> userDetails로 통일)


확인해봐야 할 사항
1. ClubService에 deleteClub에 유저정보 안쓰는데 인자에 userDetails를 왜 넣은건지, 확장성을 위한건지?
2. ClubCreateRequestDto, ClubPromotionRegisterRequestDto에 카테고리를 넣는 부분이 없어서 동아리 엔티티에 카테고리가 null로 들어감.