### PR TITLE
마이페이지 api 추가, 이미지 조회 api 수정, 회원 탈퇴 비밀번호 검증, 동아리 엔티티 누락 필드 추가

### DIFF
--- a/src/main/java/com/uniclub/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/uniclub/domain/auth/controller/AuthController.java
@@ -2,12 +2,14 @@ package com.uniclub.domain.auth.controller;
 
 import com.uniclub.domain.auth.dto.*;
 import com.uniclub.domain.auth.service.AuthService;
+import com.uniclub.global.security.UserDetailsImpl;
 import com.uniclub.global.swagger.AuthApiSpecification;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,4 +40,5 @@ public class AuthController implements AuthApiSpecification {
         StudentVerificationResponseDto studentVerificationResponseDto = authService.studentVerification(studentVerificationRequestDto);
         return ResponseEntity.status(HttpStatus.OK).body(studentVerificationResponseDto);
     }
+
 }

--- a/src/main/java/com/uniclub/domain/auth/service/AuthService.java
+++ b/src/main/java/com/uniclub/domain/auth/service/AuthService.java
@@ -88,4 +88,5 @@ public class AuthService {
         return new StudentVerificationResponseDto(verification);
     }
 
+
 }

--- a/src/main/java/com/uniclub/domain/club/dto/ClubPromotionRegisterRequestDto.java
+++ b/src/main/java/com/uniclub/domain/club/dto/ClubPromotionRegisterRequestDto.java
@@ -25,6 +25,9 @@ public class ClubPromotionRegisterRequestDto {
     @Schema(description = "모집 마감 시간", example = "2025-08-03T14:30:00")
     private LocalDateTime endTime;
 
+    @Schema(description = "동아리 한 줄 소개")
+    private String simpleDescription;
+
     @Schema(description = "소개글")
     private String description;
 
@@ -56,6 +59,7 @@ public class ClubPromotionRegisterRequestDto {
                 .status(clubStatus)
                 .startTime(startTime)
                 .endTime(endTime)
+                .simpleDescription(simpleDescription)
                 .description(description)
                 .notice(notice)
                 .location(location)

--- a/src/main/java/com/uniclub/domain/club/dto/ClubResponseDto.java
+++ b/src/main/java/com/uniclub/domain/club/dto/ClubResponseDto.java
@@ -41,7 +41,7 @@ public class ClubResponseDto {
         return ClubResponseDto.builder()
                 .id(club.getClubId())
                 .name(club.getName())
-                .info(club.getDescription())
+                .info(club.getSimpleDescription())
                 .status(club.getStatus())
                 .favorite(favorite)
                 .build();

--- a/src/main/java/com/uniclub/domain/club/entity/Club.java
+++ b/src/main/java/com/uniclub/domain/club/entity/Club.java
@@ -33,6 +33,9 @@ public class Club extends BaseTime {
     @Column
     private LocalDateTime endTime;    //모집 마감일시
 
+    @Column(length = 50)
+    private String simpleDescription;  // 동아리 한줄 소개
+
     @Column(columnDefinition = "TEXT")
     private String description;
 
@@ -62,7 +65,7 @@ public class Club extends BaseTime {
     private Category category;
 
     @Builder
-    public Club(String name, ClubStatus status, LocalDateTime startTime, LocalDateTime endTime,
+    public Club(String name, ClubStatus status, LocalDateTime startTime, LocalDateTime endTime, String simpleDescription,
                 String description, String notice, String location, String presidentName, String presidentPhone,
                 String youtubeLink, String instagramLink, String applicationFormLink, Category category) {
   
@@ -70,6 +73,7 @@ public class Club extends BaseTime {
         this.status = status;
         this.startTime = startTime;
         this.endTime = endTime;
+        this.simpleDescription = simpleDescription;
         this.description = description;
         this.notice = notice;
         this.location = location;
@@ -85,6 +89,7 @@ public class Club extends BaseTime {
         this.status = club.getStatus();
         this.startTime = club.getStartTime();
         this.endTime = club.getEndTime();
+        this.simpleDescription = club.getSimpleDescription();
         this.description = club.getDescription();
         this.notice = club.getNotice();
         this.location = club.getLocation();

--- a/src/main/java/com/uniclub/domain/club/repository/ClubRepository.java
+++ b/src/main/java/com/uniclub/domain/club/repository/ClubRepository.java
@@ -60,16 +60,11 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
 
 
     @Query("""
-    select new com.uniclub.domain.main.dto.MainPageClubResponseDto(
-        c.name,
-        m.mediaLink,
-        case when f.favoriteId is not null then true else false end
-    )
+    select c
     from Club c
     join Media m on m.club = c and m.isMain = true
-    left join Favorite f on f.club = c and f.user.userId = :userId
     where c.isDeleted = false
     order by function('rand')
     """)
-    List<MainPageClubResponseDto> getMainPageClubs(Long userId, Pageable pageable);
+    List<Club> getMainPageClubs(Pageable pageable);
 }

--- a/src/main/java/com/uniclub/domain/club/repository/MediaRepository.java
+++ b/src/main/java/com/uniclub/domain/club/repository/MediaRepository.java
@@ -22,6 +22,9 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
     @Query("SELECT m FROM Media m WHERE m.mediaType = :mediaType")
     List<Media> findByMediaType(MediaType mediaType);
 
+    @Query("SELECT m FROM Media m WHERE m.club.clubId = :clubId AND m.isMain = true")
+    Media findMainImageByClubId(Long clubId);
+
     @Modifying
     @Query("DELETE FROM Media m WHERE m.club.clubId = :clubId AND m.mediaType = :mediaType")
     void deleteByClubIdAndMediaType(Long clubId,MediaType mediaType);

--- a/src/main/java/com/uniclub/domain/user/controller/UserController.java
+++ b/src/main/java/com/uniclub/domain/user/controller/UserController.java
@@ -4,10 +4,10 @@ import com.uniclub.domain.user.dto.InformationModificationRequestDto;
 import com.uniclub.domain.user.dto.MyPageResponseDto;
 import com.uniclub.domain.user.dto.NotificationSettingResponseDto;
 import com.uniclub.domain.user.dto.ToggleNotificationResponseDto;
+import com.uniclub.domain.user.dto.UserDeleteRequestDto;
 import com.uniclub.domain.user.dto.UserRoleRequestDto;
 import com.uniclub.domain.user.service.UserService;
 import com.uniclub.global.security.UserDetailsImpl;
-import com.uniclub.global.swagger.SearchApiSpecification;
 import com.uniclub.global.swagger.UserApiSpecification;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,8 +39,10 @@ public class UserController implements UserApiSpecification {
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        userService.deleteUser(userDetails);
+    public ResponseEntity<Void> deleteUser(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody UserDeleteRequestDto userDeleteRequestDto) {
+        userService.deleteUser(userDetails, userDeleteRequestDto);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/com/uniclub/domain/user/dto/InformationModificationRequestDto.java
+++ b/src/main/java/com/uniclub/domain/user/dto/InformationModificationRequestDto.java
@@ -15,4 +15,7 @@ public class InformationModificationRequestDto {
 
     @Schema(description = "닉네임", example = "빌려온 고양이")
     private String nickname;
+
+    @Schema(description = "프로필 이미지 url", example = "uploads/2025-08-13/840d2146-c793-4ee6-83be-acb4c817c87e.png")
+    private String profileImageLink;
 }

--- a/src/main/java/com/uniclub/domain/user/dto/MyPageResponseDto.java
+++ b/src/main/java/com/uniclub/domain/user/dto/MyPageResponseDto.java
@@ -9,6 +9,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MyPageResponseDto {
 
+    @Schema(description = "닉네임", example = "라면")
+    private final String nickname;
+
     @Schema(description = "이름", example = "홍길동")
     private final String name;
 
@@ -17,4 +20,7 @@ public class MyPageResponseDto {
 
     @Schema(description = "전공", example = "컴퓨터공학부")
     private final String major;
+
+    @Schema(description = "프로필 이미지 url", example = "uploads/2025-08-13/840d2146-c793-4ee6-83be-acb4c817c87e.png")
+    private final String profileImageLink;
 }

--- a/src/main/java/com/uniclub/domain/user/dto/UserDeleteRequestDto.java
+++ b/src/main/java/com/uniclub/domain/user/dto/UserDeleteRequestDto.java
@@ -1,0 +1,15 @@
+package com.uniclub.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "회원 탈퇴 요청 DTO")
+@Getter
+@NoArgsConstructor
+public class UserDeleteRequestDto {
+    @Schema(description = "비밀번호", example = "password123!")
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/uniclub/domain/user/entity/User.java
+++ b/src/main/java/com/uniclub/domain/user/entity/User.java
@@ -31,6 +31,9 @@ public class User extends BaseTime {
     @Column(nullable = false, length = 20)
     private String major;    //전공
 
+    @Column(columnDefinition = "TEXT")
+    private String profileImageLink;  // 프로필 이미지
+
     @ColumnDefault("true")
     @Column(nullable = false)
     private boolean notificationEnabled;    //알림설정
@@ -44,15 +47,18 @@ public class User extends BaseTime {
         this.nickname = name;
     }
 
-    public void updateInfo(String name, String major, String nickname) {
+    public void updateInfo(String name, String major, String nickname, String profileImageLink) {
         if (name != null && !name.isBlank()) {
             this.name = name;
         }
         if (major != null && !major.isBlank()) {
             this.major = major;
         }
-        if(nickname != null && !nickname.isBlank()) {
+        if (nickname != null && !nickname.isBlank()) {
             this.nickname = nickname;
+        }
+        if (profileImageLink != null && !profileImageLink.isBlank()) {
+            this.profileImageLink = profileImageLink;
         }
     }
 

--- a/src/main/java/com/uniclub/domain/user/service/UserService.java
+++ b/src/main/java/com/uniclub/domain/user/service/UserService.java
@@ -9,6 +9,8 @@ import com.uniclub.domain.user.dto.InformationModificationRequestDto;
 import com.uniclub.domain.user.dto.MyPageResponseDto;
 import com.uniclub.domain.user.dto.NotificationSettingResponseDto;
 import com.uniclub.domain.user.dto.ToggleNotificationResponseDto;
+import com.uniclub.domain.user.dto.UserDeleteRequestDto;
+import com.uniclub.global.s3.S3ServiceImpl;
 import com.uniclub.domain.user.dto.UserRoleRequestDto;
 import com.uniclub.domain.user.entity.User;
 import com.uniclub.domain.user.repository.UserRepository;
@@ -18,6 +20,7 @@ import com.uniclub.global.security.UserDetailsImpl;
 import com.uniclub.global.util.EnumConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +32,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
     private final MembershipRepository membershipRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final S3ServiceImpl s3ServiceImpl;
 
     // 개인정보 수정 디자인 나오면 검증로직 추가 필요
     public void updateUser(UserDetailsImpl userDetails, InformationModificationRequestDto informationModificationRequestDto) {
@@ -42,11 +47,15 @@ public class UserService {
         }
 
         // 영속성 컨택스트 이용(더티체킹)
-        user.updateInfo(informationModificationRequestDto.getName(), informationModificationRequestDto.getMajor(), informationModificationRequestDto.getNickname());
+        user.updateInfo(informationModificationRequestDto.getName(),
+                informationModificationRequestDto.getMajor(),
+                informationModificationRequestDto.getNickname(),
+                informationModificationRequestDto.getProfileImageLink());
+
         log.info("사용자 정보 업데이트 성공: 학번={}", user.getStudentId());
     }
 
-    public void deleteUser(UserDetailsImpl userDetails) {
+    public void deleteUser(UserDetailsImpl userDetails, UserDeleteRequestDto userDeleteRequestDto) {
         // 유저 조회, 존재하지 않는 경우 예외처리
         User user = userRepository.findByStudentId(userDetails.getStudentId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -54,6 +63,16 @@ public class UserService {
         // 삭제된 유저인지 확인
         if (user.isDeleted()){
             throw new CustomException(ErrorCode.USER_DELETED);
+        }
+
+        // 비밀번호 확인
+        boolean isValid = passwordEncoder.matches(
+                userDeleteRequestDto.getPassword(),
+                userDetails.getPassword()
+        );
+        
+        if (!isValid) {
+            throw new CustomException(ErrorCode.PASSWORD_NOT_MATCHED);
         }
 
         user.softDelete();
@@ -78,9 +97,15 @@ public class UserService {
     public MyPageResponseDto getMyPage(UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         String formattedStudentId = formatStudentId(user.getStudentId());
+        
+        // 프로필 이미지 S3 키가 있으면 presigned URL 생성
+        String profileImageUrl = "";
+        if (user.getProfileImageLink() != null && !user.getProfileImageLink().isEmpty()) {
+           profileImageUrl = s3ServiceImpl.getDownloadPresignedUrl(user.getProfileImageLink());
+        }
 
         log.info("마이페이지 조회 완료: 학번={}", user.getStudentId());
-        return new MyPageResponseDto(user.getName(), formattedStudentId, user.getMajor());
+        return new MyPageResponseDto(user.getMajor(), user.getName(), formattedStudentId, user.getMajor(), profileImageUrl);
     }
 
     // 학번 추출 private 메소드

--- a/src/main/java/com/uniclub/global/exception/ErrorCode.java
+++ b/src/main/java/com/uniclub/global/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
     
     // 인증 관련
     BAD_CREDENTIALS(HttpStatus.UNAUTHORIZED, 401, "아이디 또는 비밀번호가 올바르지 않습니다."),
+    PASSWORD_NOT_MATCHED(HttpStatus.UNAUTHORIZED, 401, "비밀번호가 일치하지 않습니다."),
     
     // 데이터베이스 관련
     DATABASE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "데이터베이스 연결에 실패했습니다."),

--- a/src/main/java/com/uniclub/global/swagger/UserApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/UserApiSpecification.java
@@ -4,6 +4,7 @@ import com.uniclub.domain.user.dto.InformationModificationRequestDto;
 import com.uniclub.domain.user.dto.MyPageResponseDto;
 import com.uniclub.domain.user.dto.NotificationSettingResponseDto;
 import com.uniclub.domain.user.dto.ToggleNotificationResponseDto;
+import com.uniclub.domain.user.dto.UserDeleteRequestDto;
 import com.uniclub.domain.user.dto.UserRoleRequestDto;
 import com.uniclub.global.exception.ErrorResponse;
 import com.uniclub.global.security.UserDetailsImpl;
@@ -115,11 +116,26 @@ public interface UserApiSpecification {
             @RequestBody InformationModificationRequestDto informationModificationRequestDto
     );
 
-    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴")
+    @Operation(summary = "회원 탈퇴", description = "비밀번호 확인 후 회원 탈퇴")
     @ApiResponses({
             @ApiResponse(
                     responseCode = "204",
                     description = "탈퇴 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "비밀번호가 일치하지 않음",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject("""
+                    {
+                      "code": 401,
+                      "name": "PASSWORD_NOT_MATCHED",
+                      "message": "비밀번호가 일치하지 않습니다."
+                    }
+                    """
+                            )
+                    )
             ),
             @ApiResponse(
                     responseCode = "404",
@@ -153,7 +169,8 @@ public interface UserApiSpecification {
             )
     })
     ResponseEntity<Void> deleteUser(
-            @AuthenticationPrincipal UserDetailsImpl userDetails
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody UserDeleteRequestDto userDeleteRequestDto
     );
 
     @Operation(summary = "유저 권한 부여", description = "테스트용 - 유저에게 동아리 권한 부여")


### PR DESCRIPTION
1. 회원 탈퇴 비밀번호 검증 로직 추가
2. 동아리 엔티티 한줄소개 추가
3. 마이페이지 닉네임, 프로필 이미지 추가
4. 이미지 조회 S3 키 그대로 전송하던 문제 presigned url로 수정
