### PR TITLE
답변 완료 api 작성 및 답변 완료 후 답변 삭제 불가능 처리

### DIFF
--- a/src/main/java/com/uniclub/domain/main/dto/MainPageClubResponseDto.java
+++ b/src/main/java/com/uniclub/domain/main/dto/MainPageClubResponseDto.java
@@ -10,6 +10,11 @@ import lombok.Getter;
 @Schema(description = "메인페이지 동아리 응답 DTO")
 @Getter
 public class MainPageClubResponseDto {
+    //id값
+
+    @Schema(description = "동아리 Id", example = "1")
+    private Long clubId;
+
     @Schema(description = "동아리 이름", example = "앱센터")
     private final String name;
     
@@ -20,7 +25,8 @@ public class MainPageClubResponseDto {
     private final boolean favorite;
 
     @Builder
-    public MainPageClubResponseDto(String name, String imageUrl, boolean favorite) {
+    public MainPageClubResponseDto(Long clubId, String name, String imageUrl, boolean favorite) {
+        this.clubId = clubId;
         this.name = name;
         this.imageUrl = imageUrl;
         this.favorite = favorite;

--- a/src/main/java/com/uniclub/domain/main/service/MainService.java
+++ b/src/main/java/com/uniclub/domain/main/service/MainService.java
@@ -77,6 +77,7 @@ public class MainService {
             
             boolean isFavorite = favoriteSet.contains(club.getClubId());
             MainPageClubResponseDto dto = MainPageClubResponseDto.builder()
+                    .clubId(club.getClubId())
                     .name(club.getName())
                     .imageUrl(imageUrl)
                     .favorite(isFavorite)

--- a/src/main/java/com/uniclub/domain/qna/controller/QnaController.java
+++ b/src/main/java/com/uniclub/domain/qna/controller/QnaController.java
@@ -81,6 +81,13 @@ public class QnaController implements QnaApiSpecification {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    //회장이 질문을 답변 완료로 표시
+    @PatchMapping("/{questionId}/answered")
+    public ResponseEntity<Void> markQuestionAsAnswered(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long questionId){
+        qnaService.markQuestionAsAnswered(userDetails, questionId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
 
     /*
     //신고

--- a/src/main/java/com/uniclub/domain/qna/dto/AnswerResponseDto.java
+++ b/src/main/java/com/uniclub/domain/qna/dto/AnswerResponseDto.java
@@ -32,8 +32,11 @@ public class AnswerResponseDto {
     @Schema(description = "상위 답변 ID (대댓글인 경우)", example = "null")
     private final Long parentAnswerId;
 
+    @Schema(description = "본인 답변 여부", example = "true")
+    private final boolean owner;
+
     @Builder
-    public AnswerResponseDto(Long answerId, String name, String content, boolean anonymous, boolean deleted, LocalDateTime updateTime, Long parentAnswerId) {
+    public AnswerResponseDto(Long answerId, String name, String content, boolean anonymous, boolean deleted, LocalDateTime updateTime, Long parentAnswerId, boolean owner) {
         this.answerId = answerId;
         this.name = name;
         this.content = content;
@@ -41,9 +44,10 @@ public class AnswerResponseDto {
         this.deleted = deleted;
         this.updateTime = updateTime;
         this.parentAnswerId = parentAnswerId;
+        this.owner = owner;
     }
 
-    public static AnswerResponseDto from(Answer answer) {
+    public static AnswerResponseDto from(Answer answer, Long userId) {
         String displayName;
         if (answer.isAnonymous()) {
             displayName = "익명";
@@ -53,6 +57,9 @@ public class AnswerResponseDto {
             displayName = answer.getUser().getName();
         }
 
+        boolean owner = answer.getUser() != null &&
+                    answer.getUser().getUserId().equals(userId);
+
         return AnswerResponseDto.builder()
                 .answerId(answer.getAnswerId())
                 .name(displayName)
@@ -61,6 +68,7 @@ public class AnswerResponseDto {
                 .deleted(answer.isDeleted())
                 .updateTime(answer.getUpdateAt())
                 .parentAnswerId(answer.getParentAnswer() != null ? answer.getParentAnswer().getAnswerId() : null)
+                .owner(owner)
                 .build();
     }
 }

--- a/src/main/java/com/uniclub/domain/qna/dto/QuestionResponseDto.java
+++ b/src/main/java/com/uniclub/domain/qna/dto/QuestionResponseDto.java
@@ -20,7 +20,7 @@ public class QuestionResponseDto {
 
     @Schema(description = "질문 작성자명", example = "홍길동")
     private final String name;
-    
+
     @Schema(description = "질문 내용", example = "동아리원 모집은 언제 진행하나요?")
     private final String content;
 

--- a/src/main/java/com/uniclub/domain/qna/dto/QuestionResponseDto.java
+++ b/src/main/java/com/uniclub/domain/qna/dto/QuestionResponseDto.java
@@ -39,8 +39,14 @@ public class QuestionResponseDto {
     @Schema(description = "답변 목록")
     private final List<AnswerResponseDto> answers;
 
+    @Schema(description = "본인 질문 여부", example = "true")
+    private final boolean owner;
+
+    @Schema(description = "동아리 회장 여부", example = "false")
+    private final boolean president;
+
     @Builder
-    public QuestionResponseDto(Long questionId, String name, Long userId, String content, boolean anonymous, boolean answered, LocalDateTime updatedAt, List<AnswerResponseDto> answers) {
+    public QuestionResponseDto(Long questionId, String name, Long userId, String content, boolean anonymous, boolean answered, LocalDateTime updatedAt, List<AnswerResponseDto> answers, boolean owner, boolean president) {
         this.questionId = questionId;
         this.name = name;
         this.userId = userId;
@@ -49,9 +55,11 @@ public class QuestionResponseDto {
         this.answered = answered;
         this.updatedAt = updatedAt;
         this.answers = answers;
+        this.owner = owner;
+        this.president = president;
     }
 
-    public static QuestionResponseDto from(Question question, List<AnswerResponseDto> answers) {
+    public static QuestionResponseDto from(Question question, List<AnswerResponseDto> answers, Long userId, boolean president) {
         String displayName;
         if (question.isAnonymous()) {
             displayName = "익명";
@@ -61,15 +69,20 @@ public class QuestionResponseDto {
             displayName = question.getUser().getName();
         }
 
+        boolean owner = question.getUser() != null &&
+                       question.getUser().getUserId().equals(userId);
+
         return QuestionResponseDto.builder()
                 .questionId(question.getQuestionId())
                 .name(displayName)
-                .userId(question.getUser().getUserId())
+                .userId(question.getUser() != null ? question.getUser().getUserId() : null)
                 .content(question.getContent())
                 .anonymous(question.isAnonymous())
                 .answered(question.isAnswered())
                 .updatedAt(question.getUpdateAt())
                 .answers(answers)
+                .owner(owner)
+                .president(president)
                 .build();
 
     }

--- a/src/main/java/com/uniclub/domain/qna/dto/QuestionResponseDto.java
+++ b/src/main/java/com/uniclub/domain/qna/dto/QuestionResponseDto.java
@@ -20,10 +20,7 @@ public class QuestionResponseDto {
 
     @Schema(description = "질문 작성자명", example = "홍길동")
     private final String name;
-
-    @Schema(description = "질문 작성자 ID", example = "123")
-    private final Long userId;
-
+    
     @Schema(description = "질문 내용", example = "동아리원 모집은 언제 진행하나요?")
     private final String content;
 
@@ -46,10 +43,9 @@ public class QuestionResponseDto {
     private final boolean president;
 
     @Builder
-    public QuestionResponseDto(Long questionId, String name, Long userId, String content, boolean anonymous, boolean answered, LocalDateTime updatedAt, List<AnswerResponseDto> answers, boolean owner, boolean president) {
+    public QuestionResponseDto(Long questionId, String name, String content, boolean anonymous, boolean answered, LocalDateTime updatedAt, List<AnswerResponseDto> answers, boolean owner, boolean president) {
         this.questionId = questionId;
         this.name = name;
-        this.userId = userId;
         this.content = content;
         this.anonymous = anonymous;
         this.answered = answered;
@@ -75,7 +71,6 @@ public class QuestionResponseDto {
         return QuestionResponseDto.builder()
                 .questionId(question.getQuestionId())
                 .name(displayName)
-                .userId(question.getUser() != null ? question.getUser().getUserId() : null)
                 .content(question.getContent())
                 .anonymous(question.isAnonymous())
                 .answered(question.isAnswered())

--- a/src/main/java/com/uniclub/domain/qna/entity/Question.java
+++ b/src/main/java/com/uniclub/domain/qna/entity/Question.java
@@ -67,4 +67,8 @@ public class Question extends BaseTime{
             this.answered = answered;
         }
     }
+
+    public void markAsAnswered() {
+        this.answered = true;
+    }
 }

--- a/src/main/java/com/uniclub/domain/qna/repository/AnswerRepository.java
+++ b/src/main/java/com/uniclub/domain/qna/repository/AnswerRepository.java
@@ -10,9 +10,10 @@ import java.util.Optional;
 
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
-    //Answer Entity와 메핑된 User 조회
+    //Answer Entity와 메핑된 User, Question 조회
     @Query("SELECT a FROM Answer a " +
             "JOIN FETCH a.user " +
+            "JOIN FETCH a.question " +
             "WHERE a.answerId = :answerId " +
             "AND a.deleted = false")
     Optional<Answer> findByIdWithUser(Long answerId);

--- a/src/main/java/com/uniclub/global/exception/ErrorCode.java
+++ b/src/main/java/com/uniclub/global/exception/ErrorCode.java
@@ -70,7 +70,8 @@ public enum ErrorCode {
     //질문 관련
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "질문을 찾을 수 없습니다."),
     CANNOT_UPDATE_ANSWERED_QUESTION(HttpStatus.BAD_REQUEST, 400, "답변이 채택된 질문은 수정할 수 없습니다."),
-    ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "답변을 찾을 수 없습니다.");
+    ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "답변을 찾을 수 없습니다."),
+    CANNOT_DELETE_ANSWER_ANSWERED_QUESTION(HttpStatus.BAD_REQUEST, 400, "답변이 완료된 질문의 답변은 삭제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/uniclub/global/swagger/ClubApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/ClubApiSpecification.java
@@ -226,6 +226,7 @@ public interface ClubApiSpecification {
                             schema = @Schema(implementation = ClubPromotionResponseDto.class),
                             examples = @ExampleObject("""
                     {
+                      "role": "ADMIN",
                       "name": "앱센터",
                       "status": "ACTIVE",
                       "startTime": "2025-08-10T09:00:00",
@@ -237,11 +238,20 @@ public interface ClubApiSpecification {
                       "presidentPhone": "010-1234-5678",
                       "youtubeLink": "https://youtu.be/example",
                       "instagramLink": "https://instagram.com/appcenter",
-                      "profileImage": "https://cdn.example.com/profile.jpg",
-                      "backgroundImage": "https://cdn.example.com/bg.jpg",
-                      "mediaLinks": [
-                        "https://cdn.example.com/media1.png",
-                        "https://cdn.example.com/media2.mp4"
+                      "applicationFormLink": "https://forms.google.com/example",
+                      "mediaList": [
+                        {
+                          "mediaLink": "https://s3.amazonaws.com/bucket/presigned-url-for-media1",
+                          "mediaType": "DESCRIPTION",
+                          "isMain": true,
+                          "updatedAt": "2025-08-10T15:30:00"
+                        },
+                        {
+                          "mediaLink": "https://s3.amazonaws.com/bucket/presigned-url-for-media2",
+                          "mediaType": "DESCRIPTION",
+                          "isMain": false,
+                          "updatedAt": "2025-08-11T10:45:00"
+                        }
                       ]
                     }
                     """

--- a/src/main/java/com/uniclub/global/swagger/QnaApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/QnaApiSpecification.java
@@ -81,7 +81,6 @@ public interface QnaApiSpecification {
                     {
                       "questionId": 1,
                       "name": "홍길동",
-                      "userId": 123,
                       "content": "동아리원 모집은 언제 진행하나요?",
                       "anonymous": false,
                       "answered": true,

--- a/src/main/java/com/uniclub/global/swagger/SwaggerConfig.java
+++ b/src/main/java/com/uniclub/global/swagger/SwaggerConfig.java
@@ -20,7 +20,7 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .servers(Arrays.asList(
-                        new Server().url("http://localhost:8080")
+                        new Server().url("https://uniclub-server.inuappcenter.kr")
                 ))
                 .components(new Components()
                         // JWT 보안 스키마 추가

--- a/src/main/java/com/uniclub/global/swagger/SwaggerConfig.java
+++ b/src/main/java/com/uniclub/global/swagger/SwaggerConfig.java
@@ -20,7 +20,7 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .servers(Arrays.asList(
-                        new Server().url("https://uniclub-server.inuappcenter.kr")
+                        new Server().url("http://localhost:8080")
                 ))
                 .components(new Components()
                         // JWT 보안 스키마 추가

--- a/src/main/java/com/uniclub/global/swagger/UserApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/UserApiSpecification.java
@@ -239,7 +239,15 @@ public interface UserApiSpecification {
             @ApiResponse(
                     responseCode = "200",
                     description = "조회 성공",
-                    content = @Content(schema = @Schema(implementation = NotificationSettingResponseDto.class))
+                    content = @Content(
+                            schema = @Schema(implementation = NotificationSettingResponseDto.class),
+                            examples = @ExampleObject("""
+                    {
+                      "notificationEnabled": true
+                    }
+                    """
+                            )
+                    )
             ),
             @ApiResponse(
                     responseCode = "404",


### PR DESCRIPTION
1. answerResponseDto, QuestionResponseDto에 있는 userId 제거, 본인인지에 대한 여부 필드 포함

2. 회장이 질문에 대한 답변완료 처리 할 수 있도록 api 구현

3. swagger 반영 및 api 명세서 최신화