### PR TITLE
이름 -> 닉네임 전달로 수정, 회원가입 때 닉네임 받도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ src/main/resources/application-local.yml
 src/main/resources/application-prod.yml
 
 CLAUDE.md
+.claude/settings.local.json

--- a/src/main/java/com/uniclub/domain/auth/dto/RegisterRequestDto.java
+++ b/src/main/java/com/uniclub/domain/auth/dto/RegisterRequestDto.java
@@ -23,6 +23,10 @@ public class RegisterRequestDto {
     @NotBlank(message = "전공을 입력해주세요.")
     private String major;
 
+    @Schema(description = "닉네임", example = "밥줘배고파")
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    private String nickname;
+
     @Schema(description = "개인정보 약관 동의", example = "true")
     @NotNull(message = "개인정보 수집 및 이용 동의는 필수입니다.")
     private boolean personalInfoCollectionAgreement;

--- a/src/main/java/com/uniclub/domain/auth/service/AuthService.java
+++ b/src/main/java/com/uniclub/domain/auth/service/AuthService.java
@@ -48,7 +48,8 @@ public class AuthService {
         User user = new User(
                 registerRequestDto.getName(),
                 registerRequestDto.getStudentId(),
-                major
+                major,
+                registerRequestDto.getNickname()
         );
 
         userRepository.save(user);

--- a/src/main/java/com/uniclub/domain/qna/dto/AnswerResponseDto.java
+++ b/src/main/java/com/uniclub/domain/qna/dto/AnswerResponseDto.java
@@ -14,8 +14,8 @@ public class AnswerResponseDto {
     @Schema(description = "답변 ID", example = "1")
     private final Long answerId;
 
-    @Schema(description = "답변 작성자명", example = "홍길동")
-    private final String name;
+    @Schema(description = "답변 작성자 닉네임", example = "라면")
+    private final String nickname;
 
     @Schema(description = "답변 내용", example = "매 학기 초에 신입회원을 모집합니다.")
     private final String content;
@@ -36,9 +36,9 @@ public class AnswerResponseDto {
     private final boolean owner;
 
     @Builder
-    public AnswerResponseDto(Long answerId, String name, String content, boolean anonymous, boolean deleted, LocalDateTime updateTime, Long parentAnswerId, boolean owner) {
+    public AnswerResponseDto(Long answerId, String nickname, String content, boolean anonymous, boolean deleted, LocalDateTime updateTime, Long parentAnswerId, boolean owner) {
         this.answerId = answerId;
-        this.name = name;
+        this.nickname = nickname;
         this.content = content;
         this.anonymous = anonymous;
         this.deleted = deleted;
@@ -54,7 +54,7 @@ public class AnswerResponseDto {
         } else if (answer.getUser() == null || answer.getUser().isDeleted()) {
             displayName = "탈퇴한 사용자";
         } else {
-            displayName = answer.getUser().getName();
+            displayName = answer.getUser().getNickname();
         }
 
         boolean owner = answer.getUser() != null &&
@@ -62,7 +62,7 @@ public class AnswerResponseDto {
 
         return AnswerResponseDto.builder()
                 .answerId(answer.getAnswerId())
-                .name(displayName)
+                .nickname(displayName)
                 .content(answer.getContent())
                 .anonymous(answer.isAnonymous())
                 .deleted(answer.isDeleted())

--- a/src/main/java/com/uniclub/domain/qna/dto/QuestionResponseDto.java
+++ b/src/main/java/com/uniclub/domain/qna/dto/QuestionResponseDto.java
@@ -18,8 +18,8 @@ public class QuestionResponseDto {
     @Schema(description = "질문 ID", example = "1")
     private final Long questionId;
 
-    @Schema(description = "질문 작성자명", example = "홍길동")
-    private final String name;
+    @Schema(description = "질문 작성자 닉네임", example = "라면")
+    private final String nickname;
 
     @Schema(description = "질문 내용", example = "동아리원 모집은 언제 진행하나요?")
     private final String content;
@@ -43,9 +43,9 @@ public class QuestionResponseDto {
     private final boolean president;
 
     @Builder
-    public QuestionResponseDto(Long questionId, String name, String content, boolean anonymous, boolean answered, LocalDateTime updatedAt, List<AnswerResponseDto> answers, boolean owner, boolean president) {
+    public QuestionResponseDto(Long questionId, String nickname, String content, boolean anonymous, boolean answered, LocalDateTime updatedAt, List<AnswerResponseDto> answers, boolean owner, boolean president) {
         this.questionId = questionId;
-        this.name = name;
+        this.nickname = nickname;
         this.content = content;
         this.anonymous = anonymous;
         this.answered = answered;
@@ -62,7 +62,7 @@ public class QuestionResponseDto {
         } else if (question.getUser() == null || question.getUser().isDeleted()) {
             displayName = "탈퇴한 사용자";
         } else {
-            displayName = question.getUser().getName();
+            displayName = question.getUser().getNickname();
         }
 
         boolean owner = question.getUser() != null &&
@@ -70,7 +70,7 @@ public class QuestionResponseDto {
 
         return QuestionResponseDto.builder()
                 .questionId(question.getQuestionId())
-                .name(displayName)
+                .nickname(displayName)
                 .content(question.getContent())
                 .anonymous(question.isAnonymous())
                 .answered(question.isAnswered())

--- a/src/main/java/com/uniclub/domain/qna/dto/SearchQuestionResponseDto.java
+++ b/src/main/java/com/uniclub/domain/qna/dto/SearchQuestionResponseDto.java
@@ -11,8 +11,8 @@ public class SearchQuestionResponseDto {
     @Schema(description = "질문 ID", example = "1")
     private final Long questionId;
     
-    @Schema(description = "질문 작성자명", example = "홍길동")
-    private final String name;
+    @Schema(description = "질문 작성자 닉네임", example = "라면")
+    private final String nickname;
     
     @Schema(description = "동아리명", example = "앱센터")
     private final String clubName;
@@ -24,9 +24,9 @@ public class SearchQuestionResponseDto {
     private final Long countAnswer;
 
     @Builder
-    public SearchQuestionResponseDto(Long questionId, String name, String clubName, String content, Long countAnswer) {
+    public SearchQuestionResponseDto(Long questionId, String nickname, String clubName, String content, Long countAnswer) {
         this.questionId = questionId;
-        this.name = name;
+        this.nickname = nickname;
         this.clubName = clubName;
         this.content = content;
         this.countAnswer = countAnswer;
@@ -39,12 +39,12 @@ public class SearchQuestionResponseDto {
         } else if (question.getUser() == null || question.getUser().isDeleted()) {
             displayName = "탈퇴한 사용자";
         } else {
-            displayName = question.getUser().getName();
+            displayName = question.getUser().getNickname();
         }
 
         return SearchQuestionResponseDto.builder()
                 .questionId(question.getQuestionId())
-                .name(displayName)
+                .nickname(displayName)
                 .clubName(question.getClub().getName())
                 .content(question.getContent())
                 .countAnswer(answerCount)

--- a/src/main/java/com/uniclub/domain/user/entity/User.java
+++ b/src/main/java/com/uniclub/domain/user/entity/User.java
@@ -39,11 +39,11 @@ public class User extends BaseTime {
     private boolean notificationEnabled;    //알림설정
 
 
-    public User(String name, String studentId, Major major) {
+    public User(String name, String studentId, Major major, String nickname) {
         this.name = name;
         this.studentId = studentId;
         this.major = major;
-        this.nickname = name;
+        this.nickname = nickname;
     }
 
     public void updateInfo(String name, Major major, String nickname, Media profileMedia) {

--- a/src/main/java/com/uniclub/global/swagger/AuthApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/AuthApiSpecification.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "인증 API", description = "회원가입·로그인 관련 기능")
 public interface AuthApiSpecification {
 
-    @Operation(summary = "회원가입", description = "신규 회원 가입")
+    @Operation(summary = "회원가입", description = "신규 회원 가입 (닉네임 포함)")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "회원가입 성공"),
             @ApiResponse(

--- a/src/main/java/com/uniclub/global/swagger/QnaApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/QnaApiSpecification.java
@@ -30,14 +30,14 @@ public interface QnaApiSpecification {
                       "content": [
                         {
                           "questionId": 1,
-                          "name": "홍길동",
+                          "nickname": "라면",
                           "clubName": "앱센터",
                           "content": "동아리원 모집은 언제 진행하나요?",
                           "countAnswer": 3
                         },
                         {
                           "questionId": 2,
-                          "name": "익명",
+                          "nickname": "익명",
                           "clubName": "디자인소모임",
                           "content": "활동비는 얼마인가요?",
                           "countAnswer": 0
@@ -80,7 +80,7 @@ public interface QnaApiSpecification {
                             examples = @ExampleObject("""
                     {
                       "questionId": 1,
-                      "name": "홍길동",
+                      "nickname": "라면",
                       "content": "동아리원 모집은 언제 진행하나요?",
                       "anonymous": false,
                       "answered": true,
@@ -88,7 +88,7 @@ public interface QnaApiSpecification {
                       "answers": [
                         {
                           "answerId": 1,
-                          "name": "김동아리",
+                          "nickname": "김동아리",
                           "content": "매 학기 초에 진행합니다.",
                           "anonymous": false,
                           "deleted": false,


### PR DESCRIPTION
1. 동아리 지원폼 url 첨부 여부 필드는 굳이 필요없을 듯 함. 프론트에서 지원폼 부분 null일 때 처리할 수 있는 듯
2. question에서 유저 권한 필드 필요 X, 동아리 회장인지에 대한 여부가 이미 있음.


이후 반영사항으로 익명 번호붙이기 로직 추가 예정