### PR TITLE
fix: 댓글, 대댓글 알림 문제 해결

### DIFF
--- a/src/main/java/com/uniclub/domain/notification/service/NotificationEventProcessor.java
+++ b/src/main/java/com/uniclub/domain/notification/service/NotificationEventProcessor.java
@@ -149,14 +149,14 @@ public class NotificationEventProcessor {
     //대댓글 알림
     @Async("messageExecutor")
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void replyRegistered(Long questionId, Long answererId, String content) {
+    public void replyRegistered(Long questionId, Long parentAuthorId, String content) {
         log.info("대댓글 등록 푸시 알림 전송 시작: questionId={}", questionId);
 
         try {
             String title = truncateContent(content, 15);
             String message = "새로운 대댓글이 등록되었습니다.";
 
-            processNotification(List.of(answererId), title, message, NotificationType.QNA, questionId);
+            processNotification(List.of(parentAuthorId), title, message, NotificationType.QNA, questionId);
 
         } catch (Exception e) {
             log.warn("대댓글 알림 푸시 알림 전송 중 오류: questionId={}", questionId, e);

--- a/src/main/java/com/uniclub/domain/qna/service/QnaService.java
+++ b/src/main/java/com/uniclub/domain/qna/service/QnaService.java
@@ -1,7 +1,6 @@
 package com.uniclub.domain.qna.service;
 
 import com.uniclub.domain.block.repository.BlockRepository;
-import com.uniclub.domain.block.service.BlockService;
 import com.uniclub.domain.club.entity.Club;
 import com.uniclub.domain.club.entity.MemberShip;
 import com.uniclub.domain.club.entity.Role;
@@ -24,11 +23,17 @@ import com.uniclub.global.s3.S3Service;
 import com.uniclub.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -189,14 +194,24 @@ public class QnaService {
         }
 
 
-        // 푸시 알림 전송 및 알림 엔티티 저장 (질문 작성자가 탈퇴한 경우 알림 생략)
-        if (question.getUser() != null && !question.getUser().isDeleted()) {
-            notificationEventProcessor.answerRegisterd(questionId, answer.getAnswerId(), question.getContent(), question.getUser().getUserId());
+        // 푸시 알림 전송 및 알림 엔티티 저장
+        Long currentUserId = userDetails.getUserId();
+
+        // 답변 알림 (질문 작성자에게)
+        // - 질문 작성자가 탈퇴한 경우 생략
+        // - 본인이 자기 질문에 답변한 경우 생략
+        User questionAuthor = question.getUser();
+        if (questionAuthor != null && !questionAuthor.isDeleted() && !questionAuthor.getUserId().equals(currentUserId)) {
+            notificationEventProcessor.answerRegisterd(questionId, answer.getAnswerId(), question.getContent(), questionAuthor.getUserId());
         }
-        if (parentsAnswer != null) {   // 대댓글 알림 (부모 답변 작성자가 탈퇴한 경우 알림 생략)
+
+        // 대댓글 알림 (부모 답변 작성자에게)
+        // - 부모 답변 작성자가 탈퇴한 경우 생략
+        // - 본인이 자기 답변에 대댓글을 단 경우 생략
+        if (parentsAnswer != null) {
             User parentAnswerUser = parentsAnswer.getUser();
-            if (parentAnswerUser != null && !parentAnswerUser.isDeleted()) {
-                notificationEventProcessor.replyRegistered(questionId, parentsAnswerId, question.getContent());
+            if (parentAnswerUser != null && !parentAnswerUser.isDeleted() && !parentAnswerUser.getUserId().equals(currentUserId)) {
+                notificationEventProcessor.replyRegistered(questionId, parentAnswerUser.getUserId(), question.getContent());
             }
         }
 


### PR DESCRIPTION
## 📌 작업 내용
QnA 알림(Notification) 생성 로직의 두 가지 버그를 수정합니다.

### [문제 1] 대댓글 알림이 잘못된 사용자에게 저장되는 문제
**원인**
- `QnaService.createAnswer()`에서 `replyRegistered()` 호출 시 두 번째 인자로 `parentsAnswerId`(부모 답변의 PK)를 전달
- `NotificationEventProcessor.replyRegistered()`는 해당 인자를 그대로 `Notification.userId`에 저장
- 결과적으로 부모 답변의 `answerId` 값이 `userId` 컬럼에 들어가, 우연히 일치하는 userId를 가진 엉뚱한 사용자에게 알림이 전달됨

**해결**
- `replyRegistered()` 호출 시 `parentAnswerUser.getUserId()`(부모 답변 작성자의 userId)를 전달하도록 수정
- `replyRegistered()` 파라미터명을 `answererId` → `parentAuthorId`로 변경하여 의미 명확화

### [문제 2] 본인이 작성한 글에 본인이 답변/대댓글을 달 때도 알림이 생성되는 문제
**원인**
- 답변/대댓글 작성자와 알림 수신 대상자(질문 작성자, 부모 답변 작성자)의 동일 여부를 검증하는 로직 부재

**해결**
- `QnaService.createAnswer()` 알림 호출부에 본인 검증 조건 추가
  - 답변 알림: 질문 작성자와 답변 작성자가 동일한 경우 알림 생략
  - 대댓글 알림: 부모 답변 작성자와 대댓글 작성자가 동일한 경우 알림 생략

## 🔧 변경 파일
- `QnaService.java` - 알림 호출부 본인 검증 로직 추가, 대댓글 알림 인자 수정
- `NotificationEventProcessor.java` - `replyRegistered()` 파라미터명 변경

## ✅ 동작 검증 (시나리오)
> A=질문 작성자, B=답변 작성자, C=대댓글 작성자

| 시나리오 | 답변 알림 | 대댓글 알림 |
|---|---|---|
| A 질문 → B 답변 | A 수신 | - |
| A 질문 → A 답변 (본인 답변) | 생략 | - |
| A 질문 → B 답변 → C 대댓글 | A 수신 | B 수신 |
| A 질문 → B 답변 → B 대댓글 (본인 답변에 본인 대댓글) | A 수신 | 생략 |
| A 질문 → A 답변 → B 대댓글 | 생략 | A 수신 |
| A 질문 → A 답변 → A 대댓글 (전부 본인) | 생략 | 생략 |

## 📝 비고
- 알림 도메인의 책임 분리를 위해 본인 검증 로직은 호출부(`QnaService`)에 위치시킴
  - `NotificationEventProcessor`는 "전달받은 대상에게 알림을 발송"하는 책임만 유지
  - "알림을 보낼지 말지" 결정은 도메인 컨텍스트를 가진 호출부의 책임
- FCM 전송 안정성 개선(쓰레드 점유 이슈)은 별도 PR에서 진행 예정