### PR TITLE
fix: FCM timeout 문제 수정

### DIFF
--- a/src/main/java/com/uniclub/domain/fcm/config/FcmConfig.java
+++ b/src/main/java/com/uniclub/domain/fcm/config/FcmConfig.java
@@ -18,6 +18,11 @@ import java.io.InputStream;
 @Configuration
 public class FcmConfig {
 
+    // FCM HTTP 호출 타임아웃 (단위: ms)
+    // 무한 블로킹 방지를 위해 명시적으로 설정 (기본값 0 = 무한 대기)
+    private static final int CONNECT_TIMEOUT_MS = 5_000;
+    private static final int READ_TIMEOUT_MS = 10_000;
+
     private final ClassPathResource firebaseResource;
     private final String projectId;
 
@@ -32,14 +37,16 @@ public class FcmConfig {
         try {
             InputStream serviceAccount = firebaseResource.getInputStream();
 
-            FirebaseOptions options = new FirebaseOptions.Builder()
+            FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                     .setProjectId(projectId)
+                    .setConnectTimeout(CONNECT_TIMEOUT_MS)
+                    .setReadTimeout(READ_TIMEOUT_MS)
                     .build();
 
             if (FirebaseApp.getApps().isEmpty()) {
                 FirebaseApp.initializeApp(options);
-                log.info("Firebase Admin SDK 초기화 완료 - Project ID: {}", projectId);
+                log.info("Firebase Admin SDK 초기화 완료 - Project ID: {}, connectTimeout: {}ms, readTimeout: {}ms", projectId, CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS);
             }
 
         } catch (IOException e) {

--- a/src/main/java/com/uniclub/domain/fcm/service/FcmService.java
+++ b/src/main/java/com/uniclub/domain/fcm/service/FcmService.java
@@ -1,5 +1,6 @@
 package com.uniclub.domain.fcm.service;
 
+import com.google.api.core.ApiFuture;
 import com.google.firebase.messaging.*;
 import com.uniclub.domain.fcm.dto.FcmMessageDto;
 import com.uniclub.domain.fcm.dto.FcmResponseDto;
@@ -13,11 +14,18 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FcmService {
+
+    // 개별 토큰당 FCM 전송 최대 대기 시간 (SDK timeout의 fallback 역할)
+    // SDK readTimeout보다 약간 길게 설정하여 SDK timeout이 우선 작동
+    private static final long SEND_TIMEOUT_SECONDS = 15L;
 
     private final FcmTokenRepository fcmTokenRepository;
 
@@ -46,37 +54,27 @@ public class FcmService {
         int failureCount = 0;
         List<String> invalidTokens = new ArrayList<>();
 
-        //각 토큰에 개별 전송
+        //각 토큰에 개별 전송 (토큰별 예외 격리)
         for (String token : fcmMessageDto.getTokens()) {
-            try {
-                Message message = Message.builder()
-                        .setToken(token)
-                        .setNotification(Notification.builder()
-                                .setTitle(fcmMessageDto.getTitle())
-                                .setBody(fcmMessageDto.getContent())
-                                .build())
-                        .build();
+            SendStatus status = sendToToken(token, fcmMessageDto.getTitle(), fcmMessageDto.getContent());
 
-                //개별 전송
-                String messageId = FirebaseMessaging.getInstance().send(message);
-                successCount++;
-                log.debug("FCM 전송 성공: messageId={}", messageId);
-
-            } catch (FirebaseMessagingException e) {
-                failureCount++;
-                log.error("FCM 전송 실패: token={}, errorCode={}, message={}",
-                        token.substring(0, Math.min(20, token.length())) + "...",
-                        e.getMessagingErrorCode(),
-                        e.getMessage());
-
-                // 유효하지 않은 토큰 수집
-                if (isInvalidToken(e)) {
+            switch (status) {
+                case SUCCESS -> successCount++;
+                case FAILURE_RETRYABLE -> failureCount++;
+                case FAILURE_INVALID_TOKEN -> {
+                    failureCount++;
                     invalidTokens.add(token);
                 }
             }
+
+            //인터럽트 신호 시 루프 중단
+            if (Thread.currentThread().isInterrupted()) {
+                log.warn("FCM 전송 인터럽트 감지, 루프 중단");
+                break;
+            }
         }
 
-        // 유효하지 않은 토큰 삭제
+        //유효하지 않은 토큰 삭제
         if (!invalidTokens.isEmpty()) {
             deleteInvalidTokensSync(invalidTokens);
         }
@@ -89,6 +87,54 @@ public class FcmService {
                         .failureCount(failureCount)
                         .build()
         );
+    }
+
+    /**
+     * 단일 토큰에 FCM 전송
+     * 모든 예외를 흡수하여 루프 중단을 방지하고, 결과 상태만 반환
+     */
+    private SendStatus sendToToken(String token, String title, String content) {
+        ApiFuture<String> future = null;
+        try {
+            Message message = Message.builder()
+                    .setToken(token)
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(content)
+                            .build())
+                    .build();
+
+            //비동기 전송 + 강제 타임아웃
+            future = FirebaseMessaging.getInstance().sendAsync(message);
+            String messageId = future.get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            log.debug("FCM 전송 성공: messageId={}", messageId);
+            return SendStatus.SUCCESS;
+
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            log.warn("FCM 전송 타임아웃: token={}, timeout={}s", maskToken(token), SEND_TIMEOUT_SECONDS);
+            return SendStatus.FAILURE_RETRYABLE;
+
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof FirebaseMessagingException fme) {
+                log.error("FCM 전송 실패: token={}, errorCode={}, message={}", maskToken(token), fme.getMessagingErrorCode(), fme.getMessage());
+                return isInvalidToken(fme) ? SendStatus.FAILURE_INVALID_TOKEN : SendStatus.FAILURE_RETRYABLE;
+            }
+            log.error("FCM 전송 중 예외: token={}, cause={}", maskToken(token), cause != null ? cause.getMessage() : "unknown");
+            return SendStatus.FAILURE_RETRYABLE;
+
+        } catch (InterruptedException e) {
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+            log.warn("FCM 전송 인터럽트: token={}", maskToken(token));
+            return SendStatus.FAILURE_RETRYABLE;
+
+        } catch (RuntimeException e) {
+            //예상치 못한 런타임 예외도 토큰별로 격리하여 루프 중단 방지
+            log.error("FCM 전송 중 예상치 못한 오류: token={}, message={}", maskToken(token), e.getMessage(), e);
+            return SendStatus.FAILURE_RETRYABLE;
+        }
     }
 
     @Transactional
@@ -105,5 +151,20 @@ public class FcmService {
         return errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT;
     }
 
+    //토큰 마스킹 (로그용)
+    private String maskToken(String token) {
+        return token.substring(0, Math.min(20, token.length())) + "...";
+    }
 
+    /**
+     * FCM 단일 토큰 전송 결과
+     * - SUCCESS: 전송 성공
+     * - FAILURE_RETRYABLE: 일시적 실패 (네트워크/타임아웃/일반 오류 - 다음에 재시도 가능)
+     * - FAILURE_INVALID_TOKEN: 토큰 자체 문제 (만료/등록취소 - DB에서 삭제 대상)
+     */
+    private enum SendStatus {
+        SUCCESS,
+        FAILURE_RETRYABLE,
+        FAILURE_INVALID_TOKEN
+    }
 }


### PR DESCRIPTION
## 📌 작업 내용
FCM 푸시 알림 전송 과정에서 네트워크 이슈 등으로 무한 블로킹이 발생하여 SIGKILL 발생 이전까지 워커 쓰레드를 점유하던 문제를 해결합니다.

### 문제 상황
- FCM 전송 중 네트워크 단절·서버 지연 발생 시 워커 쓰레드가 무기한 블로킹
- `sendExecutor` 풀(maxPoolSize=20)이 모두 점유되면 신규 알림이 큐에 누적
- 결과적으로 SIGKILL이 떨어질 때까지 쓰레드가 회수되지 않음

### 원인 분석
1. **SDK 레벨 timeout 미설정**
   - `FirebaseOptions` 빌드 시 `setConnectTimeout`/`setReadTimeout` 미지정 → SDK 기본값(0 = 무한 대기) 적용
2. **애플리케이션 레벨 timeout 부재**
   - `FirebaseMessaging.send()` 동기 호출 사용 → 강제 cutoff 수단 없음
3. **예외 처리 범위 좁음**
   - `FirebaseMessagingException`만 catch → `IOException`, `RuntimeException` 등은 잡히지 않아 루프 중단 가능
   - 한 토큰의 예외가 전체 알림 발송을 죽이는 구조

### 해결 방안
3단계 안전장치를 적용하여 다중 방어선 구성

#### Step 1. SDK 레벨 timeout 설정 (`FcmConfig`)
- `FirebaseOptions`에 `setConnectTimeout(5초)`, `setReadTimeout(10초)` 명시
- `new FirebaseOptions.Builder()` (deprecated) → `FirebaseOptions.builder()` 정적 팩토리 메서드로 변경

#### Step 2. 애플리케이션 레벨 timeout (`FcmService`)
- `FirebaseMessaging.send()` (동기) → `sendAsync()` (비동기) + `future.get(15s, TimeUnit.SECONDS)` 으로 변경
- SDK timeout이 작동하지 않는 예외 케이스에 대한 fallback
- `TimeoutException` 발생 시 `future.cancel(true)` 호출하여 백그라운드 작업도 명시적 종료

#### Step 3. 토큰별 예외 격리 (`FcmService`)
- 단일 토큰 전송 로직을 `sendToToken()` 메서드로 추출하여 책임 분리
- 모든 예외(`TimeoutException`, `ExecutionException`, `InterruptedException`, `RuntimeException`)를 catch하여 토큰별로 격리
- `Error`는 catch하지 않음 (`OutOfMemoryError` 등은 정상 전파되어야 함)
- 전송 결과를 `SendStatus` enum(SUCCESS / FAILURE_RETRYABLE / FAILURE_INVALID_TOKEN)으로 표현
  - 일시적 실패와 토큰 자체 문제를 명확히 구분
  - 일시적 실패는 invalid 토큰으로 분류하지 않아 다음 발송 시 재시도 가능
- `InterruptedException` 표준 패턴 적용 (`Thread.currentThread().interrupt()` + 루프 중단)

[애플리케이션 레벨]   future.get(15s)         ← 최후 방어선
↓
[SDK 레벨]           readTimeout(10s)         ← 우선 작동
connectTimeout(5s)
↓
[FCM 서버]

## 🔧 변경 파일
- `FcmConfig.java` - FirebaseOptions에 connect/read timeout 설정
- `FcmService.java` - 비동기 전송 + 강제 timeout, 토큰별 예외 격리, SendStatus enum 도입

## ✅ 동작 검증 (시나리오)

| 시나리오 | 처리 결과 |
|---|---|
| 정상 전송 | SUCCESS, 다음 토큰 진행 |
| FCM 서버 응답 없음 | SDK readTimeout(10s) → ExecutionException → FAILURE_RETRYABLE |
| SDK timeout 미작동 | 애플리케이션 timeout(15s) → future.cancel → FAILURE_RETRYABLE |
| 토큰 만료/등록취소 | FirebaseMessagingException → FAILURE_INVALID_TOKEN → DB에서 자동 삭제 |
| 일시적 네트워크 오류 | TimeoutException → FAILURE_RETRYABLE (invalid 분류 X, 재시도 가능) |
| 예상치 못한 RuntimeException | 격리 후 다음 토큰 진행 (에러 로그 기록) |
| OOM 등 Error | 정상 전파 (시스템이 적절히 종료) |
| 외부 인터럽트 | future.cancel + 인터럽트 신호 보존 후 루프 중단 |

## 📝 비고
- 다수 사용자 발송 시 한 토큰의 어떤 문제도 다른 토큰의 전송에 영향을 주지 않도록 격리
- 무한 블로킹 발생 시에도 최대 15초 내에 다음 토큰으로 진행 보장
- 향후 개선 가능 영역(별도 PR 대상)
  - `messageExecutor` 큐 포화 모니터링
  - 발송 실패 토큰에 대한 재시도 정책 도입