### PR TITLE
fix: 알림 설정 토클시 푸시알림 전송되지 않도록 수정

### DIFF
--- a/src/main/java/com/uniclub/domain/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/com/uniclub/domain/fcm/repository/FcmTokenRepository.java
@@ -1,21 +1,22 @@
 package com.uniclub.domain.fcm.repository;
 
 import com.uniclub.domain.fcm.entity.FcmToken;
-import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
-    @Query("SELECT ft.token FROM FcmToken ft WHERE ft.userId IN :userIds")
-    List<String> findTokensByUserIds(List<Long> userIds);
 
-    Optional<FcmToken> findByToken(String fcmToken);
+    @Query("SELECT ft.token FROM FcmToken ft " +
+            "JOIN User u ON ft.userId = u.userId " +
+            "WHERE ft.userId IN :userIds " +
+            "AND u.notificationEnabled = true " +
+            "AND u.deleted = false")
+    List<String> findTokensByUserIds(List<Long> userIds);
 
     @Modifying
     @Query(value =


### PR DESCRIPTION
## 📌 작업 내용
알림 토글 OFF 상태인 사용자에게도 FCM 푸시가 발송되던 문제 수정

## 🔍 원인
`User.notificationEnabled` 필드와 토글 API는 이미 구현되어 있었으나, FCM 발송 시점에 해당 플래그를 확인하는 로직이 누락됨

## 🔧 변경 내용
`FcmTokenRepository.findTokensByUserIds()` 쿼리에 필터링 조건 추가
- `notificationEnabled = true` (알림 OFF 사용자 제외)
- `deleted = false` (탈퇴 사용자 제외)

```java
@Query("SELECT ft.token FROM FcmToken ft " +
       "JOIN User u ON ft.userId = u.userId " +
       "WHERE ft.userId IN :userIds " +
       "AND u.notificationEnabled = true " +
       "AND u.deleted = false")
List<String> findTokensByUserIds(List<Long> userIds);
```

## 📝 비고
- 푸시만 차단되며, 앱 내 알림(`Notification` 테이블)은 정상 저장 → 토글 OFF 사용자도 앱 진입 시 알림 목록 확인 가능
- 백엔드 필터링 방식 채택 (프론트 토큰 삭제 방식 대비: 토글 ON 복귀 시 토큰 재발급 실패 위험 제거, invalid 토큰 자동 삭제 로직과의 의미 충돌 방지)