### PR TITLE
add: media file delete api 생성

### DIFF
--- a/src/main/java/com/uniclub/domain/club/controller/ClubController.java
+++ b/src/main/java/com/uniclub/domain/club/controller/ClubController.java
@@ -86,4 +86,13 @@ public class ClubController implements ClubApiSpecification {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @DeleteMapping("/{clubId}/images")
+    public ResponseEntity<Void> deleteClubMedia(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long clubId,
+            @Valid @RequestBody MediaDeleteRequestDto mediaDeleteRequestDto) {
+        clubService.deleteClubMedia(userDetails, clubId, mediaDeleteRequestDto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
 }

--- a/src/main/java/com/uniclub/domain/club/dto/MediaDeleteRequestDto.java
+++ b/src/main/java/com/uniclub/domain/club/dto/MediaDeleteRequestDto.java
@@ -1,0 +1,18 @@
+package com.uniclub.domain.club.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Schema(description = "미디어 삭제 요청 DTO")
+@Getter
+@NoArgsConstructor
+public class MediaDeleteRequestDto {
+
+    @Schema(description = "삭제할 미디어 ID 목록", example = "[1, 2, 3]")
+    @NotEmpty(message = "삭제할 미디어 ID 목록을 입력해주세요.")
+    private List<Long> mediaIds;
+}

--- a/src/main/java/com/uniclub/domain/club/repository/MediaRepository.java
+++ b/src/main/java/com/uniclub/domain/club/repository/MediaRepository.java
@@ -1,10 +1,8 @@
 package com.uniclub.domain.club.repository;
 
-import com.uniclub.domain.club.entity.Club;
 import com.uniclub.domain.club.entity.Media;
 import com.uniclub.domain.club.entity.MediaType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -14,23 +12,19 @@ import java.util.List;
 
 @Repository
 public interface MediaRepository extends JpaRepository<Media, Long> {
-    @Query("SELECT m FROM Media m WHERE m.club.clubId = :clubId")
+    @Query("SELECT m FROM Media m WHERE m.club.clubId = :clubId AND m.deleted = false")
     List<Media> findByClubId(Long clubId);
 
-    @Modifying
-    @Query("UPDATE Media m SET m.mainMedia = false WHERE m.club = :club AND m.mainMedia = true")
-    List<Media> findByClubAndIsMainTrue(Club club);
-
-    @Query("SELECT m FROM Media m WHERE m.mediaType = :mediaType")
+    @Query("SELECT m FROM Media m WHERE m.mediaType = :mediaType AND m.deleted = false")
     List<Media> findByMediaType(MediaType mediaType);
 
-    @Query("SELECT m FROM Media m JOIN FETCH m.club WHERE m.club.clubId IN :clubIds AND m.mediaType = 'CLUB_PROFILE'")
+    @Query("SELECT m FROM Media m JOIN FETCH m.club WHERE m.club.clubId IN :clubIds AND m.mediaType = 'CLUB_PROFILE' AND m.deleted = false")
     List<Media> findClubProfilesByClubIds(List<Long> clubIds);
 
-    @Modifying
-    @Query("DELETE FROM Media m WHERE m.club.clubId = :clubId AND m.mediaType = :mediaType")
-    void deleteByClubIdAndMediaType(Long clubId,MediaType mediaType);
+    @Query("SELECT m FROM Media m WHERE m.club.clubId = :clubId AND m.mediaType = :mediaType AND m.deleted = false")
+    List<Media> findByClubIdAndMediaType(@Param("clubId") Long clubId, @Param("mediaType") MediaType mediaType);
 
     @Query("SELECT m FROM Media m WHERE m.deleted = true AND m.deletedAt < :cutoffDate")
     List<Media> findDeletedMediaBeforeDate(@Param("cutoffDate") LocalDateTime cutoffDate);
+
 }

--- a/src/main/java/com/uniclub/domain/club/service/ClubService.java
+++ b/src/main/java/com/uniclub/domain/club/service/ClubService.java
@@ -235,6 +235,49 @@ public class ClubService {
         log.info("역할 변경 완료: studentId={}, clubId={}, role={}", requestDto.getStudentId(), club.getClubId(), role);
     }
 
+    //동아리 미디어 삭제 (soft delete)
+    public void deleteClubMedia(UserDetailsImpl userDetails, Long clubId, MediaDeleteRequestDto mediaDeleteRequestDto) {
+        List<Long> mediaIds = mediaDeleteRequestDto.getMediaIds();
+        log.info("동아리 미디어 삭제 시작: clubId={}, userId={}, mediaIds={}", clubId, userDetails.getUserId(), mediaIds);
+
+        //동아리 존재/활성 상태 검증
+        findActiveClub(clubId);
+
+        //해당 동아리의 운영진인지 확인
+        Role userRole = checkRole(userDetails.getUserId(), clubId);
+        if (userRole != Role.PRESIDENT && userRole != Role.ADMIN) {
+            throw new CustomException(ErrorCode.INSUFFICIENT_PERMISSION);
+        }
+
+        //요청된 ID로 미디어 조회
+        List<Media> mediaList = mediaRepository.findAllById(mediaIds);
+
+        //존재하지 않는 ID가 있는지 검증
+        if (mediaList.size() != mediaIds.size()) {
+            throw new CustomException(ErrorCode.MEDIA_NOT_FOUND);
+        }
+
+        //모든 미디어가 해당 동아리 소속이며, MAIN_PAGE가 아니고, 아직 삭제되지 않았는지 검증
+        for (Media media : mediaList) {
+            if (media.getClub() == null || !media.getClub().getClubId().equals(clubId)) {
+                throw new CustomException(ErrorCode.MEDIA_CLUB_MISMATCH);
+            }
+            if (media.getMediaType() == MediaType.MAIN_PAGE) {
+                throw new CustomException(ErrorCode.MEDIA_TYPE_MISMATCH);
+            }
+            if (media.isDeleted()) {
+                throw new CustomException(ErrorCode.MEDIA_ALREADY_DELETED);
+            }
+        }
+
+        //soft delete 수행 (실제 S3 삭제는 MediaDeleteScheduler가 6개월 뒤 처리)
+        for (Media media : mediaList) {
+            media.softDelete();
+        }
+        log.info("동아리 미디어 삭제 완료: clubId={}, userId={}, deletedCount={}, mediaIds={}",
+                clubId, userDetails.getUserId(), mediaList.size(), mediaIds);
+    }
+
 
     //특정 동아리 유저 권한 확인 (정보 없으면 GUEST로 반환)
     private Role checkRole(Long userId, Long clubId) {
@@ -306,21 +349,27 @@ public class ClubService {
     }
 
     private void deleteExistingUniqueMediaType(Long clubId, List<ClubMediaUploadRequestDto> clubMediaUploadRequestDtoList) {
-        //새로 업로드 되는 것 확인
-        Set<String> newMediaTypes = clubMediaUploadRequestDtoList.stream()
-                .map(ClubMediaUploadRequestDto::getMediaType)
+        //새로 업로드 되는 것 확인 (String → MediaType 변환하여 Set 구성)
+        Set<MediaType> newMediaTypes = clubMediaUploadRequestDtoList.stream()
+                .map(dto -> EnumConverter.stringToEnum(dto.getMediaType(), MediaType.class, ErrorCode.MEDIA_TYPE_NOT_FOUND))
                 .collect(Collectors.toSet());
 
-        //CLUB_PROFILE이 새로 업로드될 예정이면 기존 파일 삭제
+        //CLUB_PROFILE이 새로 업로드될 예정이면 기존 파일 soft delete
         if (newMediaTypes.contains(MediaType.CLUB_PROFILE)) {
-            mediaRepository.deleteByClubIdAndMediaType(clubId, MediaType.CLUB_PROFILE);
-            log.info("기존 동아리 프로필 이미지 삭제: clubId={}", clubId);
+            List<Media> existing = mediaRepository.findByClubIdAndMediaType(clubId, MediaType.CLUB_PROFILE);
+            existing.forEach(Media::softDelete);
+            if (!existing.isEmpty()) {
+                log.info("기존 동아리 프로필 이미지 soft delete: clubId={}, count={}", clubId, existing.size());
+            }
         }
 
-        //CLUB_BACKGROUND가 새로 업로드될 예정이면 기존 파일 삭제
+        //CLUB_BACKGROUND가 새로 업로드될 예정이면 기존 파일 soft delete
         if (newMediaTypes.contains(MediaType.CLUB_BACKGROUND)) {
-            mediaRepository.deleteByClubIdAndMediaType(clubId, MediaType.CLUB_BACKGROUND);
-            log.info("기존 동아리 배경 이미지 삭제: clubId={}", clubId);
+            List<Media> existing = mediaRepository.findByClubIdAndMediaType(clubId, MediaType.CLUB_BACKGROUND);
+            existing.forEach(Media::softDelete);
+            if (!existing.isEmpty()) {
+                log.info("기존 동아리 배경 이미지 soft delete: clubId={}, count={}", clubId, existing.size());
+            }
         }
     }
 

--- a/src/main/java/com/uniclub/domain/main/controller/MainController.java
+++ b/src/main/java/com/uniclub/domain/main/controller/MainController.java
@@ -3,6 +3,7 @@ package com.uniclub.domain.main.controller;
 import com.uniclub.domain.main.dto.MainMediaUploadRequestDto;
 import com.uniclub.domain.main.dto.MainPageClubResponseDto;
 import com.uniclub.domain.main.dto.MainPageMediaResponseDto;
+import com.uniclub.domain.club.dto.MediaDeleteRequestDto;
 import com.uniclub.domain.main.service.MainService;
 import com.uniclub.global.security.UserDetailsImpl;
 import com.uniclub.global.swagger.MainApiSpecification;
@@ -39,10 +40,9 @@ public class MainController implements MainApiSpecification {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    /*
     @DeleteMapping("/banner")
-    public ResponseEntity<Void> deleteMainPageMedia(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-
+    public ResponseEntity<Void> deleteMainBanner(@Valid @RequestBody MediaDeleteRequestDto mediaDeleteRequestDto) {
+        mainService.deleteMainMedia(mediaDeleteRequestDto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
-    */
 }

--- a/src/main/java/com/uniclub/domain/main/service/MainService.java
+++ b/src/main/java/com/uniclub/domain/main/service/MainService.java
@@ -1,14 +1,15 @@
 package com.uniclub.domain.main.service;
 
-import com.uniclub.domain.club.entity.Club;
+import com.uniclub.domain.club.dto.MediaDeleteRequestDto;
 import com.uniclub.domain.club.entity.Media;
 import com.uniclub.domain.club.entity.MediaType;
 import com.uniclub.domain.club.repository.ClubRepository;
 import com.uniclub.domain.club.repository.MediaRepository;
-import com.uniclub.domain.favorite.repository.FavoriteRepository;
 import com.uniclub.domain.main.dto.MainMediaUploadRequestDto;
 import com.uniclub.domain.main.dto.MainPageClubResponseDto;
 import com.uniclub.domain.main.dto.MainPageMediaResponseDto;
+import com.uniclub.global.exception.CustomException;
+import com.uniclub.global.exception.ErrorCode;
 import com.uniclub.global.s3.S3Service;
 import com.uniclub.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -18,9 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 @Slf4j
 @Service
@@ -30,7 +29,6 @@ public class MainService {
 
     private final ClubRepository clubRepository;
     private final MediaRepository mediaRepository;
-    private final FavoriteRepository favoriteRepository;
     private final S3Service s3Service;
 
 
@@ -97,6 +95,36 @@ public class MainService {
             uploadedMediaInfo.add("MAIN_PAGE" + ":" + fileName);
         }
         log.info("메인페이지 미디어 업로드 완료: upload_media={}", uploadedMediaInfo);
+    }
+
+    //메인 페이지 배너 미디어 삭제 (soft delete)
+    public void deleteMainMedia(MediaDeleteRequestDto mediaDeleteRequestDto) {
+        List<Long> mediaIds = mediaDeleteRequestDto.getMediaIds();
+        log.info("메인페이지 배너 삭제 요청: mediaIds={}", mediaIds);
+
+        //요청된 ID로 미디어 조회
+        List<Media> mediaList = mediaRepository.findAllById(mediaIds);
+
+        //존재하지 않는 ID가 있는지 검증
+        if (mediaList.size() != mediaIds.size()) {
+            throw new CustomException(ErrorCode.MEDIA_NOT_FOUND);
+        }
+
+        //타입 및 삭제 여부 검증
+        for (Media media : mediaList) {
+            if (media.getMediaType() != MediaType.MAIN_PAGE) {
+                throw new CustomException(ErrorCode.MEDIA_TYPE_MISMATCH);
+            }
+            if (media.isDeleted()) {
+                throw new CustomException(ErrorCode.MEDIA_ALREADY_DELETED);
+            }
+        }
+
+        //soft delete 수행 (실제 S3 삭제는 MediaDeleteScheduler가 6개월 뒤 처리)
+        for (Media media : mediaList) {
+            media.softDelete();
+        }
+        log.info("메인페이지 배너 삭제 완료: deletedCount={}, mediaIds={}", mediaList.size(), mediaIds);
     }
 
 

--- a/src/main/java/com/uniclub/global/exception/ErrorCode.java
+++ b/src/main/java/com/uniclub/global/exception/ErrorCode.java
@@ -40,8 +40,10 @@ public enum ErrorCode {
     FILE_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, 400, "업로드 가능한 파일 개수를 초과했습니다."),
     S3_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "파일 저장소 연결에 실패했습니다."),
     DUPLICATE_MEDIA_TYPE(HttpStatus.BAD_REQUEST, 400, "해당 타입의 이미지는 동아리만 하나만 등록 가능합니다."),
-
-
+    MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 미디어를 찾을 수 없습니다."),
+    MEDIA_ALREADY_DELETED(HttpStatus.GONE, 410, "이미 삭제된 미디어입니다."),
+    MEDIA_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, 400, "요청한 미디어 타입과 일치하지 않습니다."),
+    MEDIA_CLUB_MISMATCH(HttpStatus.BAD_REQUEST, 400, "해당 동아리에 속하지 않은 미디어입니다."),
 
     //JWT
     JWT_ENTRY_POINT(HttpStatus.UNAUTHORIZED, 401, "인증되지 않은 사용자입니다."),

--- a/src/main/java/com/uniclub/global/swagger/ClubApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/ClubApiSpecification.java
@@ -451,5 +451,70 @@ public interface ClubApiSpecification {
     ResponseEntity<Void> changeMemberRole(
             @Valid @RequestBody MemberRoleChangeRequestDto requestDto
     );
+    @Operation(summary = "동아리 미디어 삭제", description = "동아리 미디어 다건 삭제 (soft delete, 6개월 후 S3에서 물리 삭제). 회장/관리자만 가능.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "다른 동아리의 미디어이거나 메인 페이지 미디어",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject("""
+                {
+                  "code": 400,
+                  "name": "MEDIA_CLUB_MISMATCH",
+                  "message": "해당 동아리에 속하지 않은 미디어입니다."
+                }
+                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject("""
+                {
+                  "code": 403,
+                  "name": "INSUFFICIENT_PERMISSION",
+                  "message": "사용 권한이 없습니다."
+                }
+                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "동아리 또는 미디어 찾기 실패",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject("""
+                {
+                  "code": 404,
+                  "name": "MEDIA_NOT_FOUND",
+                  "message": "해당 미디어를 찾을 수 없습니다."
+                }
+                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "410",
+                    description = "이미 삭제된 미디어 또는 동아리",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject("""
+                {
+                  "code": 410,
+                  "name": "MEDIA_ALREADY_DELETED",
+                  "message": "이미 삭제된 미디어입니다."
+                }
+                """)
+                    )
+            )
+    })
+    ResponseEntity<Void> deleteClubMedia(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long clubId,
+            @Valid @RequestBody MediaDeleteRequestDto mediaDeleteRequestDto
+    );
 
 }

--- a/src/main/java/com/uniclub/global/swagger/MainApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/MainApiSpecification.java
@@ -1,5 +1,6 @@
 package com.uniclub.global.swagger;
 
+import com.uniclub.domain.club.dto.MediaDeleteRequestDto;
 import com.uniclub.domain.main.dto.MainMediaUploadRequestDto;
 import com.uniclub.domain.main.dto.MainPageClubResponseDto;
 import com.uniclub.domain.main.dto.MainPageMediaResponseDto;
@@ -90,5 +91,58 @@ public interface MainApiSpecification {
     })
     ResponseEntity<Void> uploadClubMedia(
             @RequestBody List<MainMediaUploadRequestDto> mainMediaUploadRequestDtoList
+    );
+
+    @Operation(summary = "메인페이지 배너 삭제", description = "메인페이지 배너 미디어 다건 삭제 (soft delete, 6개월 후 S3에서 물리 삭제)")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "삭제 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "요청한 미디어 타입과 일치하지 않음",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject("""
+                {
+                  "code": 400,
+                  "name": "MEDIA_TYPE_MISMATCH",
+                  "message": "요청한 미디어 타입과 일치하지 않습니다."
+                }
+                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "미디어 찾기 실패",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject("""
+                {
+                  "code": 404,
+                  "name": "MEDIA_NOT_FOUND",
+                  "message": "해당 미디어를 찾을 수 없습니다."
+                }
+                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "410",
+                    description = "이미 삭제된 미디어",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject("""
+                {
+                  "code": 410,
+                  "name": "MEDIA_ALREADY_DELETED",
+                  "message": "이미 삭제된 미디어입니다."
+                }
+                """)
+                    )
+            )
+    })
+    ResponseEntity<Void> deleteMainBanner(
+            @RequestBody MediaDeleteRequestDto mediaDeleteRequestDto
     );
 }


### PR DESCRIPTION
## 📌 작업 요약

메인 페이지 배너 및 동아리 이미지의 **삭제·수정 기능**을 추가하고, 기존 미디어 삭제 로직을 프로젝트 컨벤션(soft delete + 스케줄 기반 S3 정리)에 맞게 정비했습니다.

## ✨ 주요 변경 사항

### 1. 메인 배너 다건 삭제 API 추가
- `DELETE /api/v1/main/banner`
- `MediaDeleteRequestDto`로 `mediaIds` 다건 수신
- 검증: 존재 여부, `MAIN_PAGE` 타입 일치, 이미 삭제 여부
- 추후 ADMIN 권한 체크는 어플리케이션 관리자 페이지 작업 시 추가 예정

### 2. 동아리 미디어 다건 삭제 API 추가
- `DELETE /api/v1/clubs/{clubId}/media`
- 권한: `PRESIDENT`, `ADMIN`만 가능 (기존 `uploadClubMedia` 패턴 재사용)
- 검증: 권한 → 존재 여부 → 동아리 소속 일치 → 타입 → 이미 삭제 여부 순으로 수행 (다른 동아리 미디어 ID 탐색 차단)

### 3. 이미지 수정
- 별도 PATCH/PUT 엔드포인트 없이 **삭제 API + 기존 업로드 API 조합**으로 처리
- 이미지 수정은 본질적으로 "기존 S3 객체 정리 + 새 객체 업로드"이므로 별도 update 시맨틱이 불필요

### 4. 삭제 정책
- **즉시 삭제 X** → `Media.softDelete()` 호출 (DB row 유지)
- 기존 `MediaDeleteScheduler`가 6개월 뒤 S3 + DB에서 일괄 물리 삭제
- 사용자 실수 복구 여지 확보 + 프로젝트 전체 soft delete 컨벤션과 일치

### 5. 기존 결함 해소
- **버그 픽스**: `ClubService.deleteExistingUniqueMediaType()`에서 `Set<String>.contains(MediaType enum)` 비교가 항상 false였던 문제 수정 → `Set<MediaType>`으로 변경
- **하드 삭제 → soft delete 전환**: `mediaRepository.deleteByClubIdAndMediaType()`(하드 삭제)이 S3 고아 파일을 누적시키던 문제 해결. 조회 후 `softDelete()` 호출 방식으로 변경
- **조회 쿼리 soft delete 일관성**: `findByClubId`, `findByMediaType`, `findClubProfilesByClubIds`에 `deleted = false` 필터 추가. soft delete된 Media가 메인 페이지/홍보 페이지/검색 결과에 노출되던 문제 차단
- **Dead code 제거**: 사용처 없던 `findByClubAndIsMainTrue` 제거

## 📂 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `global/exception/ErrorCode.java` | `MEDIA_NOT_FOUND`, `MEDIA_ALREADY_DELETED`, `MEDIA_TYPE_MISMATCH`, `MEDIA_CLUB_MISMATCH` 추가 |
| `domain/club/dto/MediaDeleteRequestDto.java` | 신규 (`mediaIds` + `@NotEmpty`) |
| `domain/club/repository/MediaRepository.java` | `findByClubIdAndMediaType` 추가, `deleteByClubIdAndMediaType`/`findByClubAndIsMainTrue` 제거, 3개 조회 쿼리에 `deleted = false` 필터 추가 |
| `domain/main/service/MainService.java` | `deleteMainMedia()` 추가 |
| `domain/main/controller/MainController.java` | `DELETE /banner` 핸들러 추가 |
| `domain/club/service/ClubService.java` | `deleteClubMedia()` 추가, `deleteExistingUniqueMediaType()` 수정 |
| `domain/club/controller/ClubController.java` | `DELETE /{clubId}/media` 핸들러 추가 |
| `global/swagger/MainApiSpecification.java` | Swagger 정의 추가 |
| `global/swagger/ClubApiSpecification.java` | Swagger 정의 추가 |

## 🧪 동작 확인

- 메인 배너 업로드 → 삭제 → `GET /main/banner` 응답에서 제외 확인
- 동아리 프로필 이미지 업로드 → 재업로드(교체) 시 기존 row가 `deleted=true`로 변경, 신규 row만 응답에 노출
- 다른 동아리의 `mediaId` 섞어 요청 시 `MEDIA_CLUB_MISMATCH` 응답
- 이미 삭제된 `mediaId` 재요청 시 `MEDIA_ALREADY_DELETED` 응답

## ⚙️ 추후 작업 (별도 PR)

- 메인 배너 삭제 API에 ADMIN 권한 체크 (관리자 페이지 작업 시 함께)
- 누적된 soft delete 데이터 정리(필요 시 일회성 스크립트)