### PR TITLE
add: 메인, 동아리 조회시 mediaId 필드 추가

### DIFF
--- a/src/main/java/com/uniclub/domain/club/dto/DescriptionMediaDto.java
+++ b/src/main/java/com/uniclub/domain/club/dto/DescriptionMediaDto.java
@@ -2,20 +2,34 @@ package com.uniclub.domain.club.dto;
 
 import com.uniclub.domain.club.entity.Media;
 import com.uniclub.domain.club.entity.MediaType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "동아리 홍보페이지 미디어 응답 DTO")
 @Getter
 public class DescriptionMediaDto {
+
+    @Schema(description = "미디어 PK", example = "1")
+    private final Long mediaId;
+
+    @Schema(description = "미디어 링크 URL")
     private final String mediaLink;
+
+    @Schema(description = "미디어 타입", example = "CLUB_PROMOTION")
     private final MediaType mediaType;
+
+    @Schema(description = "메인 이미지 여부", example = "true")
     private final boolean main;
+
+    @Schema(description = "수정 시각", example = "2025-08-10T15:30:00")
     private final LocalDateTime updatedAt;
 
     @Builder
-    public DescriptionMediaDto(String mediaLink, MediaType mediaType, boolean main, LocalDateTime updatedAt) {
+    public DescriptionMediaDto(Long mediaId, String mediaLink, MediaType mediaType, boolean main, LocalDateTime updatedAt) {
+        this.mediaId = mediaId;
         this.mediaLink = mediaLink;
         this.mediaType = mediaType;
         this.main = main;
@@ -24,6 +38,7 @@ public class DescriptionMediaDto {
 
     public static DescriptionMediaDto from(Media media, String presingedUrl) {
         return DescriptionMediaDto.builder()
+                .mediaId(media.getMediaId())
                 .mediaLink(presingedUrl)
                 .mediaType(media.getMediaType())
                 .main(media.isMainMedia())

--- a/src/main/java/com/uniclub/domain/main/dto/MainPageMediaResponseDto.java
+++ b/src/main/java/com/uniclub/domain/main/dto/MainPageMediaResponseDto.java
@@ -1,6 +1,5 @@
 package com.uniclub.domain.main.dto;
 
-import com.uniclub.domain.club.dto.DescriptionMediaDto;
 import com.uniclub.domain.club.entity.Media;
 import com.uniclub.domain.club.entity.MediaType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,20 +9,26 @@ import lombok.Getter;
 @Schema(description = "메인페이지 미디어 응답 DTO")
 @Getter
 public class MainPageMediaResponseDto {
+
+    @Schema(description = "미디어 PK", example = "1")
+    private final Long mediaId;
+
     @Schema(description = "미디어 링크 URL", example = "https://example.com/main-image.jpg")
     private final String mediaLink;
-    
+
     @Schema(description = "미디어 타입", example = "MAIN_PAGE")
     private final MediaType mediaType;
 
     @Builder
-    public MainPageMediaResponseDto(String mediaLink, MediaType mediaType) {
+    public MainPageMediaResponseDto(Long mediaId, String mediaLink, MediaType mediaType) {
+        this.mediaId = mediaId;
         this.mediaLink = mediaLink;
         this.mediaType = mediaType;
     }
 
     public static MainPageMediaResponseDto from(Media media, String presignedUrl) {
         return MainPageMediaResponseDto.builder()
+                .mediaId(media.getMediaId())
                 .mediaLink(presignedUrl)
                 .mediaType(media.getMediaType())
                 .build();

--- a/src/main/java/com/uniclub/domain/qna/controller/QnaController.java
+++ b/src/main/java/com/uniclub/domain/qna/controller/QnaController.java
@@ -105,5 +105,7 @@ public class QnaController implements QnaApiSpecification {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    //차단
+
 
 }

--- a/src/main/java/com/uniclub/global/swagger/ClubApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/ClubApiSpecification.java
@@ -243,12 +243,14 @@ public interface ClubApiSpecification {
                       "applicationFormLink": "https://forms.google.com/example",
                       "mediaList": [
                         {
+                          "mediaId": 1,
                           "mediaLink": "https://uniclubs3.s3.ap-northeast-2.amazonaws.com/uploads/2025-08-13/840d2146-c793-4ee6-83be-acb4c817c87e.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20250813T162429Z&X-Amz-SignedHeaders=host&X-Amz-Expires=1200&X-Amz-Credential=AKIAYHJAM5L7YOWJHC4E%2F20250813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=46a114c0ef5c5921b9ea480b5fd10a197a7dfcafb782e633487fec858de4",
                           "mediaType": "DESCRIPTION",
                           "main": true,
                           "updatedAt": "2025-08-10T15:30:00"
                         },
                         {
+                          "mediaId": 2,
                           "mediaLink": "https://uniclubs3.s3.ap-northeast-2.amazonaws.com/uploads/2025-08-13/840d2146-c793-4ee6-83be-acb4c817c87e.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20250813T162429Z&X-Amz-SignedHeaders=host&X-Amz-Expires=1200&X-Amz-Credential=AKIAYHJAM5L7YOWJHC4E%2F20250813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=46a114c0ef5c5921b9ea480b5fd10a197a7dfcafb782e633487fec858de4",
                           "mediaType": "DESCRIPTION",
                           "main": false,

--- a/src/main/java/com/uniclub/global/swagger/MainApiSpecification.java
+++ b/src/main/java/com/uniclub/global/swagger/MainApiSpecification.java
@@ -32,10 +32,12 @@ public interface MainApiSpecification {
                             examples = @ExampleObject("""
                                     [
                                       {
+                                        "mediaId": 1,
                                         "mediaLink": "https://uniclubs3.s3.ap-northeast-2.amazonaws.com/uploads/2025-08-13/840d2146-c793-4ee6-83be-acb4c817c87e.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20250813T162429Z&X-Amz-SignedHeaders=host&X-Amz-Expires=1200&X-Amz-Credential=AKIAYHJAM5L7YOWJHC4E%2F20250813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=46a114c0ef5c5921b9ea480b5fd10a197a7dfcafb782e633487fec858de4",
                                         "mediaType": "MAIN_PAGE"
                                       },
                                       {
+                                        "mediaId": 2,
                                         "mediaLink": "https://uniclubs3.s3.ap-northeast-2.amazonaws.com/uploads/2025-08-13/840d2146-c793-4ee6-83be-acb4c817c87e.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20250813T162429Z&X-Amz-SignedHeaders=host&X-Amz-Expires=1200&X-Amz-Credential=AKIAYHJAM5L7YOWJHC4E%2F20250813%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=46a114c0ef5c5921b9ea480b5fd10a197a7dfcafb782e633487fec858de4",
                                         "mediaType": "MAIN_PAGE"
                                       }


### PR DESCRIPTION
## 변경 사항
- 동아리 홍보페이지 / 메인페이지 미디어 조회 응답에 `mediaId` 필드 추가
- 프론트엔드가 미디어 삭제 API 호출 시 PK를 식별할 수 있도록 응답 스펙 보완

## 변경 파일
- `DescriptionMediaDto`: `mediaId` 필드 추가, 모든 필드 `@Schema` 통일
- `MainPageMediaResponseDto`: `mediaId` 필드 추가, 미사용 import 제거
- `ClubApiSpecification`, `MainApiSpecification`: Swagger 예시 응답 동기화

## 배경
미디어 삭제 API(`DELETE /api/v1/clubs/{clubId}/media`, `DELETE /api/v1/main/media`)는 `mediaIds: List<Long>`을 요구하지만, 기존 조회 API 응답에 `mediaId`가 없어 프론트가 식별자를 알 수 없었음. presigned URL은 매 요청마다 서명이 갱신되어 식별자로 사용 불가하므로 PK 노출로 해결.